### PR TITLE
Updates to itemsContract and zomgStoreContract

### DIFF
--- a/src/zolar/item/ZolarItems.scilla
+++ b/src/zolar/item/ZolarItems.scilla
@@ -18,6 +18,7 @@ let true = True
 let zero = Uint256 0
 let one = Uint256 1
 let empty_string = ""
+let item_type_key = "Type"
 
 let add_operation = Add
 let sub_operation = Sub
@@ -43,19 +44,27 @@ let get_bal =
     | Some bal => bal
     end
 
-let get_head_of_list =
-  fun (list : List (Pair String String)) =>
-    let list_head = @list_head (Pair String String) in
-    let maybe_head = list_head list in
-    match maybe_head with
-    | None =>
-      Pair {String String} empty_string empty_string
-    | Some head =>
-      head
+(* gets the trait of given traitKey from a list of traits *)
+let get_trait_value = 
+  fun (traits_list : List (Pair String String)) =>
+  fun (traitKey: String) =>
+    let get_value = @list_find (Pair String String) in
+    let fn =
+      fun (trait: Pair String String) =>
+        match trait with
+        | Pair key value =>
+          builtin eq key traitKey
+        end
+    in
+    let maybe_trait_value = get_value fn traits_list in
+    match maybe_trait_value with
+    | None => empty_string
+    | Some trait_value =>
+      match trait_value with
+      | Pair key value =>
+        value
+      end
     end
-
-(* extracts the head from Pair (String, String) *)
-let get_head_of_pair : Pair String String -> String = @fst String String
 
 (* Error exception *)
 type Error =
@@ -328,9 +337,8 @@ procedure RequireDifferentItemType(
   match maybe_item_traits with
   | None =>
   | Some item_traits =>
-    item_trait = get_head_of_list item_traits;
-    trait_key = get_head_of_pair item_trait;
-    maybe_item_type_flag <- parent_owned_types[to_contract][to_token_id][trait_key];
+    item_type_value = get_trait_value item_traits item_type_key;
+    maybe_item_type_flag <- parent_owned_types[to_contract][to_token_id][item_type_value];
     match maybe_item_type_flag with
     | None =>
     | Some item_type_flag =>
@@ -1027,13 +1035,12 @@ procedure TransferItemToParent(
     match maybe_item_traits with
     | None =>
     | Some item_traits =>
-      item_trait = get_head_of_list item_traits;
-      trait_key = get_head_of_pair item_trait;
-      is_traitless = builtin eq trait_key empty_string;
+      item_type_value = get_trait_value item_traits item_type_key;
+      is_traitless = builtin eq item_type_value empty_string;
       match is_traitless with
       | True =>
       | False =>
-        parent_owned_types[to_contract][to_token_id][trait_key] := true
+        parent_owned_types[to_contract][to_token_id][item_type_value] := true
       end
     end
   end
@@ -1064,13 +1071,12 @@ procedure TransferItemFromParent(
     match maybe_item_traits with
     | None =>
     | Some item_traits =>
-      item_trait = get_head_of_list item_traits;
-      trait_key = get_head_of_pair item_trait;
-      is_traitless = builtin eq trait_key empty_string;
+      item_type_value = get_trait_value item_traits item_type_key;
+      is_traitless = builtin eq item_type_value empty_string;
       match is_traitless with
       | True =>
       | False =>
-        parent_owned_types[from_contract][from_token_id][trait_key] := false
+        parent_owned_types[from_contract][from_token_id][item_type_value] := false
       end
     end
   end

--- a/src/zolar/item/ZolarItems.scilla
+++ b/src/zolar/item/ZolarItems.scilla
@@ -44,28 +44,6 @@ let get_bal =
     | Some bal => bal
     end
 
-(* gets the trait of given traitKey from a list of traits *)
-let get_trait_value = 
-  fun (traits_list : List (Pair String String)) =>
-  fun (traitKey: String) =>
-    let get_value = @list_find (Pair String String) in
-    let fn =
-      fun (trait: Pair String String) =>
-        match trait with
-        | Pair key value =>
-          builtin eq key traitKey
-        end
-    in
-    let maybe_trait_value = get_value fn traits_list in
-    match maybe_trait_value with
-    | None => empty_string
-    | Some trait_value =>
-      match trait_value with
-      | Pair key value =>
-        value
-      end
-    end
-
 (* Error exception *)
 type Error =
   | NotPausedError
@@ -102,7 +80,6 @@ type Error =
   | MaxItemDepthReachedError
   | ConsumerFoundError
   | ConsumerNotFoundError
-  | ItemTypeAlreadyOwned
 
 let make_error =
   fun (result: Error) =>
@@ -142,7 +119,6 @@ let make_error =
       | MaxItemDepthReachedError           => Int32 -32
       | ConsumerFoundError                 => Int32 -33
       | ConsumerNotFoundError              => Int32 -34
-      | ItemTypeAlreadyOwned               => Int32 -35
       end
     in
     { _exception: "Error"; code: result_code }
@@ -211,10 +187,6 @@ field token_owners: Map Uint256 ByStr20 = Emp Uint256 ByStr20
 
 (* Mapping of item id to its respective parent token*)
 field parent_owners: Map Uint256 Pair ByStr20 Uint256 = Emp Uint256 Pair ByStr20 Uint256
-
-(* Mapping of parent token to its types of items owned *)
-(* parent_token_contract : { token_id : { 'headgear': 1, 'armor': 1, 'off-hand': 0 } } *)
-field parent_owned_types: Map ByStr20 (Map Uint256 (Map String Bool)) = Emp ByStr20 (Map Uint256 (Map String Bool))
 
 (* The total number of tokens minted *)
 field token_id_count: Uint256 = Uint256 0
@@ -325,30 +297,6 @@ procedure RequireNotZeroAddress(address: ByStr20)
     error = TokenNotFoundError;
     Throw error
   | False =>
-  end
-end
-
-procedure RequireDifferentItemType(
-  item_id: Uint256,
-  to_token_id: Uint256,
-  to_contract: ByStr20
-)
-  maybe_item_traits <- traits[item_id];
-  match maybe_item_traits with
-  | None =>
-  | Some item_traits =>
-    item_type_value = get_trait_value item_traits item_type_key;
-    maybe_item_type_flag <- parent_owned_types[to_contract][to_token_id][item_type_value];
-    match maybe_item_type_flag with
-    | None =>
-    | Some item_type_flag =>
-      match item_type_flag with
-      | True =>
-        error = ItemTypeAlreadyOwned;
-        Throw error
-      | False =>
-      end
-    end
   end
 end
 
@@ -1025,24 +973,10 @@ procedure TransferItemToParent(
     RequireItemNotParent to_token_id to_contract item_id _this_address;
     RequireTokenOwner item_id _sender;
     RequireRootOwner to_token_id to_contract;
-    RequireDifferentItemType item_id to_token_id to_contract;
 
     new_parent_token = Pair {ByStr20 Uint256} to_contract to_token_id;
     parent_owners[item_id] := new_parent_token;
-    token_owners[item_id] := to_contract;
-    
-    maybe_item_traits <- traits[item_id];
-    match maybe_item_traits with
-    | None =>
-    | Some item_traits =>
-      item_type_value = get_trait_value item_traits item_type_key;
-      is_traitless = builtin eq item_type_value empty_string;
-      match is_traitless with
-      | True =>
-      | False =>
-        parent_owned_types[to_contract][to_token_id][item_type_value] := true
-      end
-    end
+    token_owners[item_id] := to_contract
   end
 end
 
@@ -1065,20 +999,7 @@ procedure TransferItemFromParent(
     RequireRootOwner from_token_id from_contract;
 
     delete parent_owners[item_id];
-    token_owners[item_id] := _sender;
-
-    maybe_item_traits <- traits[item_id];
-    match maybe_item_traits with
-    | None =>
-    | Some item_traits =>
-      item_type_value = get_trait_value item_traits item_type_key;
-      is_traitless = builtin eq item_type_value empty_string;
-      match is_traitless with
-      | True =>
-      | False =>
-        parent_owned_types[from_contract][from_token_id][item_type_value] := false
-      end
-    end
+    token_owners[item_id] := _sender
   end
 end
 

--- a/src/zolar/item/ZolarItems.scilla
+++ b/src/zolar/item/ZolarItems.scilla
@@ -18,7 +18,6 @@ let true = True
 let zero = Uint256 0
 let one = Uint256 1
 let empty_string = ""
-let item_type_key = "Type"
 
 let add_operation = Add
 let sub_operation = Sub

--- a/src/zolar/item/ZolarOMGShop.scilla
+++ b/src/zolar/item/ZolarOMGShop.scilla
@@ -19,6 +19,8 @@ let hundred_percent_bps = Uint128 10000
 let hundred = Uint128 100
 let empty_pair = Pair {Uint128 Uint128} zero zero
 let zero_address = 0x0000000000000000000000000000000000000000
+let item_type_key = "Type"
+let empty_string = ""
 
 (* Error events *)
 type Error =
@@ -33,6 +35,9 @@ type Error =
   | CodeInvalidPaymentItemCount
   | CodeInvalidPaymentItemToken
   | CodeInvalidPaymentItemTraits
+  | CodeNotTokenOwner
+  | CodeInvalidItemContract
+  | CodeItemNotValidConsumable
 
 type CraftingCost =
   | CraftingCost of ByStr20 Uint128 (List (Pair String String)) (* item token address, quantity, item traits *)
@@ -58,6 +63,9 @@ let make_error =
       | CodeInvalidPaymentItemCount           => Int32 -9
       | CodeInvalidPaymentItemToken           => Int32 -10
       | CodeInvalidPaymentItemTraits          => Int32 -11
+      | CodeNotTokenOwner                     => Int32 -12
+      | CodeInvalidItemContract               => Int32 -13
+      | CodeItemNotValidConsumable            => Int32 -14
       end
     in
     { _exception : "Error"; code : result_code }
@@ -129,6 +137,28 @@ let is_traits_exist =
     let empty_list = Nil {Bool} in
     let result = fold fn empty_list candidate in
     all_true result
+
+(* gets the trait of key "Type" from a list of traits *)
+let get_trait_value = 
+  fun (traits_list : List (Pair String String)) =>
+  fun (traitKey: String) =>
+    let get_value = @list_find (Pair String String) in
+    let fn =
+      fun (trait: Pair String String) =>
+        match trait with
+        | Pair key value =>
+          builtin eq key traitKey
+        end
+    in
+    let maybe_trait_value = get_value fn traits_list in
+    match maybe_trait_value with
+    | None => empty_string
+    | Some trait_value =>
+      match trait_value with
+      | Pair key value =>
+        value
+      end
+    end
   
 
 let get_amount_or_zero =
@@ -172,6 +202,7 @@ field pending_owner : Option ByStr20 = none
 field items : Map Uint128 Item = Emp Uint128 Item
 field transact_count : Map Uint128 (Pair Uint128 Uint128) = Emp Uint128 (Pair Uint128 Uint128) (* id => (net_purchase, net_inflation) *)
 field next_item_id : Uint128 = zero
+field consumable_whitelist : Map String Bool = Emp String Bool (* map of consumableName : isConsumable *)
 
 (**************************************)
 (*             Procedures             *)
@@ -329,6 +360,75 @@ procedure MintItem(token_address: ByStr20, traits: List (Pair String String))
   send msgs
 end
 
+(* for each payment_item, check if it belongs to _sender *)
+procedure VerifyOwnership(payment_item: PaymentItem)
+  match payment_item with
+  | PaymentItem token_contract_address token_id =>
+    maybe_token_contract <- & token_contract_address as ByStr20 with contract
+      field token_owners : Map Uint256 ByStr20
+    end;
+    match maybe_token_contract with
+    | None =>
+      (* throw error invalid contract *)
+      err = CodeInvalidItemContract;
+      ThrowError err
+    | Some token_contract =>
+      (* check if token_owners[token_id] === _sender *)
+      maybe_token_owner <- & token_contract.token_owners[token_id];
+      token_owner = match maybe_token_owner with | Some v => v | None => zero_address end;
+      is_token_owner = builtin eq token_owner _sender;
+      match is_token_owner with
+      | True => (* no op, token_owner matches _sender *)
+      | False =>
+        (* throw error as _sender is not token_owner *)
+        err = CodeNotTokenOwner;
+        ThrowError err
+      end
+    end
+  end
+end
+
+procedure VerifyAndConsumeItem (token_id: Uint256, token_contract_address: ByStr20)
+  (* check if item is on consumable whitelist *)
+  maybe_item_contract <- & token_contract_address as ByStr20 with contract
+    field traits : Map Uint256 (List (Pair String String))
+  end;
+  match maybe_item_contract with
+  | None =>
+    (* invalid item_contract with no traits field, throw err *)
+    err = CodeInvalidItemContract;
+    ThrowError err
+  | Some item_contract =>
+    (* get item traits *)
+    maybe_traits <- & item_contract.traits[token_id];
+    match maybe_traits with
+    | None =>
+      (* throw error as item not a valid consumable *)
+      err = CodeItemNotValidConsumable;
+      ThrowError err
+    | Some traits =>
+      item_type = get_trait_value traits item_type_key;
+      maybe_consumable_mapping <- consumable_whitelist[item_type];
+      is_valid_consumable = match maybe_consumable_mapping with | None => false | Some v => v end;
+      match is_valid_consumable with
+      | True =>
+        (* expend item and emit event for db to track, as item is valid *)
+        ExpendZRC6 token_contract_address token_id;
+        e = {
+          _eventname: "ItemConsumed";
+          token_id: token_id;
+          token_contract_address: token_contract_address;
+          item_type: item_type
+        };
+        event e
+      | False =>
+        (* throw error as item not a valid consumable *)
+        err = CodeItemNotValidConsumable;
+        ThrowError err
+      end
+    end
+  end
+end
 
 (***************************************)
 (*             Transitions             *)
@@ -344,11 +444,22 @@ transition CraftItem(item_id: Uint128, payment_items: List PaymentItem)
     ThrowError err
   | Some item =>
     match item with
-    | Item name token_address traits crafting_costs  =>
+    | Item name token_address traits crafting_costs =>
+      forall payment_items VerifyOwnership;
       VerifyAndReceivePayment crafting_costs payment_items;
       MintItem token_address traits
     end
   end
+end
+
+(* @dev: Consumes an item from a given contract, must be on consumable white-list *)
+(* @param item_id: the id of the item to consume *)
+transition ConsumeItem(token_id: Uint256, token_contract_address: ByStr20)
+  token = PaymentItem token_contract_address token_id;
+  (* check if item to be consumed belongs to _sender *)
+  VerifyOwnership token;
+  (* check if item is a valid consumable (on the consumable_whitelist) and consume if so *)
+  VerifyAndConsumeItem token_id token_contract_address
 end
 
 (***************************************************)
@@ -407,6 +518,28 @@ transition RemoveItem(item_id: Uint128)
   | Some item =>
     delete items[item_id]
   end
+end
+
+(* @dev: Adds a consumable to the consumable_whitelist *)
+(* @param name: Name of consumable to be added *)
+transition AddConsumable(name: String)
+  consumable_whitelist[name] := true;
+  e = {
+    _eventname: "ConsumableAdded";
+    item_name: name
+  };
+  event e
+end
+
+(* @dev: Removes a consumable from the consumable_whitelist *)
+(* @param name: Name of consumable to be removed *)
+transition RemoveConsumable(name: String)
+  consumable_whitelist[name] := false;
+  e = {
+    _eventname: "ConsumableRemoved";
+    item_name: name
+  };
+  event e
 end
 
 (***************************************)

--- a/src/zolar/item/ZolarOMGShop.scilla
+++ b/src/zolar/item/ZolarOMGShop.scilla
@@ -516,7 +516,10 @@ transition RemoveItem(item_id: Uint128)
     err = CodeItemNotFound;
     ThrowError err
   | Some item =>
-    delete items[item_id]
+    delete items[item_id];
+
+    e = {_eventname : "ItemRemoved"; item_id: item_id; item: item};
+    event e
   end
 end
 


### PR DESCRIPTION
- Update implementation of `RequireItemDifferentType` check in `ItemContract`, now finding the `Trait` with specific key `Type`, instead of assuming it will be the head of the `TraitsList`.
- Add `VerifyOwnership` check on `ZOMGContract`, that verifies ownership of each `PaymentItem` before crafting is allowed.
- Add `ConsumeItem` transition to consume item and emit event for backend to track. (Item must be part of `consumable_whitelist` based on item's trait value of key `Type`).
- Add `AddConsumable` and `RemoveConsumable` transitions to add items to the whitelist.