### PR TITLE
add tests for quests, items and gem-refinery, minor bug fix for zomg test, and minor bug fixes to items and gem refinery contract

### DIFF
--- a/src/zolar/item/ZolarGemRefinery.scilla
+++ b/src/zolar/item/ZolarGemRefinery.scilla
@@ -439,7 +439,7 @@ procedure ChargeFees(payer: ByStr20, amount: Uint128)
     _tag: "Burn";
     _recipient: fee_address;
     _amount: zero;
-    burn_account: _sender;
+    burn_account: payer;
     amount: amount
   };
 

--- a/src/zolar/item/ZolarItems.scilla
+++ b/src/zolar/item/ZolarItems.scilla
@@ -60,7 +60,6 @@ type Error =
   | OperatorFoundError
   | NotAllowedToTransferError
   | TokenNotFoundError
-  | InvalidFeeBPSError
   | ZeroAddressDestinationError
   | ThisAddressDestinationError
   | CodeNotTokenOwner
@@ -99,27 +98,26 @@ let make_error =
       | OperatorFoundError                 => Int32 -12
       | NotAllowedToTransferError          => Int32 -13
       | TokenNotFoundError                 => Int32 -14
-      | InvalidFeeBPSError                 => Int32 -15
-      | ZeroAddressDestinationError        => Int32 -16
-      | ThisAddressDestinationError        => Int32 -17
-      | NotContractOwnershipRecipientError => Int32 -18
-      | CodeNotTokenOwner                  => Int32 -19
-      | ItemOwnedError                     => Int32 -20
-      | ItemNotOwnedError                  => Int32 -21
-      | ItemWrongParentError               => Int32 -22
-      | ParentTokenNotFoundError           => Int32 -23
-      | NotRootOwnerError                  => Int32 -24
-      | InvalidParentContractError         => Int32 -25
-      | InvalidParentContract2Error        => Int32 -26
-      | InvalidParentContract3Error        => Int32 -27
-      | InvalidItemContractError           => Int32 -28
-      | ItemCannotBeParentError            => Int32 -29
-      | ItemCannotBeParentError2           => Int32 -30
-      | ItemCannotBeParentError3           => Int32 -31
-      | MaxItemDepthReachedError           => Int32 -32
-      | ConsumerFoundError                 => Int32 -33
-      | ConsumerNotFoundError              => Int32 -34
-      | ItemSelfError                      => Int32 -35
+      | ZeroAddressDestinationError        => Int32 -15
+      | ThisAddressDestinationError        => Int32 -16
+      | NotContractOwnershipRecipientError => Int32 -17
+      | CodeNotTokenOwner                  => Int32 -18
+      | ItemOwnedError                     => Int32 -19
+      | ItemNotOwnedError                  => Int32 -20
+      | ItemWrongParentError               => Int32 -21
+      | ParentTokenNotFoundError           => Int32 -22
+      | NotRootOwnerError                  => Int32 -23
+      | InvalidParentContractError         => Int32 -24
+      | InvalidParentContract2Error        => Int32 -25
+      | InvalidParentContract3Error        => Int32 -26
+      | InvalidItemContractError           => Int32 -27
+      | ItemCannotBeParentError            => Int32 -28
+      | ItemCannotBeParentError2           => Int32 -29
+      | ItemCannotBeParentError3           => Int32 -30
+      | MaxItemDepthReachedError           => Int32 -31
+      | ConsumerFoundError                 => Int32 -32
+      | ConsumerNotFoundError              => Int32 -33
+      | ItemSelfError                      => Int32 -34
       end
     in
     { _exception: "Error"; code: result_code }
@@ -768,6 +766,9 @@ end
 procedure RequireAccessToTransfer(token_owner: ByStr20, token_id: Uint256)  
   (* check if _sender is token owner *)
   is_token_owner = builtin eq token_owner _sender;
+
+  (* check if _sender is consumer *)
+  is_consumer <- exists consumers[_sender];
   
   (* check if _sender is spender *)
   maybe_spender <- spenders[token_id];
@@ -780,8 +781,8 @@ procedure RequireAccessToTransfer(token_owner: ByStr20, token_id: Uint256)
   (* check if _sender is operator *)
   is_operator <- exists operators[token_owner][_sender];
   
-  is_spender_or_operator = orb is_spender is_operator;
-  is_allowed = orb is_spender_or_operator is_token_owner;
+  is_spender_or_operator_or_consumer = let is_spender_or_operator = orb is_spender is_operator in orb is_spender_or_operator is_consumer;
+  is_allowed = orb is_spender_or_operator_or_consumer is_token_owner;
   match is_allowed with
   | True =>
   | False =>

--- a/tests/zolar/mission-2/gem-refinery.test.js
+++ b/tests/zolar/mission-2/gem-refinery.test.js
@@ -1,0 +1,339 @@
+const { getAddressFromPrivateKey } = require("@zilliqa-js/zilliqa");
+const { getPrivateKey, param } = require("../../../scripts/zilliqa");
+const { createRandomAccount } = require("../../../scripts/account");
+const { callContract } = require("../../../scripts/call");
+const { deployItems, deployHunyToken, deployResource, deployGemRefinery, ONE_HUNY } = require("../../../scripts/zolar/mission-2/helper");
+const { adt } = require("./helper")
+const { generateErrorMsg } = require('../bank/helper')
+
+let privateKey, memberPrivateKey, address, memberAddress, itemsAddress, itemsContract, geodeAddress, geodeContract, hunyAddress, hunyContract, gemRefineryAddress, gemRefineryContract
+
+beforeAll(async () => {
+  // deploy refinery, items, geode, huny
+  // add refinery as minter for items, geode and huny
+  // add refinery as consumer for items
+  // increase allowance for gem-refinery for geode contract to transfer
+
+  // gem-refinery checks
+  // refine geodes
+  // enhance gems
+  // refine/enhance when not enough huny for fees
+  // refine when not enough geodes
+  // enhance when not enough gems
+  // enhance when gems belong to another user
+
+  privateKey = getPrivateKey();
+  address = getAddressFromPrivateKey(privateKey).toLowerCase();
+
+  ; ({ key: memberPrivateKey, address: memberAddress } = await createRandomAccount(privateKey, '1000'))
+
+  itemsContract = await deployItems({ baseUri: "https://test-api.zolar.io/items/metadata/" });
+  itemsAddress = itemsContract.address.toLowerCase();
+
+  hunyContract = await deployHunyToken({ name: "Huny Token", symbol: "HUNY", decimals: "12" });
+  hunyAddress = hunyContract.address.toLowerCase();
+
+  geodeContract = await deployResource("ZolarGeode", { name: "Geode - Zolar Resource", symbol: "zlrGEODE", decimals: "2" });
+  geodeAddress = geodeContract.address.toLowerCase();
+
+  gemRefineryContract = await deployGemRefinery({ geodeAddress, itemsAddress, feeAddress: hunyAddress, refinementFee: ONE_HUNY.times(10), enhancementFee: ONE_HUNY.times(100)});
+  gemRefineryAddress = gemRefineryContract.address.toLowerCase();
+
+  const txAddMinterHuny = await callContract(privateKey, hunyContract, "AddMinter", [
+    param('minter', 'ByStr20', gemRefineryAddress),
+  ], 0, false, false)
+  console.log(txAddMinterHuny.id)
+
+  const txAddMinterResource = await callContract(privateKey, geodeContract, "AddMinter", [
+    param('minter', 'ByStr20', gemRefineryAddress),
+  ], 0, false, false)
+  console.log(txAddMinterResource.id)
+
+  const txAddMinterItems = await callContract(privateKey, itemsContract, "AddMinter", [
+    param('minter', 'ByStr20', gemRefineryAddress),
+  ], 0, false, false)
+  console.log(txAddMinterItems.id)
+
+  const txAddConsumerItems = await callContract(privateKey, itemsContract, "AddConsumer", [
+    param('consumer', 'ByStr20', gemRefineryAddress),
+  ], 0, false, false)
+  console.log(txAddConsumerItems.id)
+
+  const txIncreaseAllowance1 = await callContract(privateKey, geodeContract, "IncreaseAllowance", [
+    param('spender', 'ByStr20', gemRefineryAddress),
+    param('amount', 'Uint128', "10000000000000")
+  ], 0, false, false)
+  console.log(txIncreaseAllowance1.id)
+
+  const txIncreaseAllowance2 = await callContract(memberPrivateKey, geodeContract, "IncreaseAllowance", [
+    param('spender', 'ByStr20', gemRefineryAddress),
+    param('amount', 'Uint128', "10000000000000")
+  ], 0, false, false)
+  console.log(txIncreaseAllowance2.id)
+})
+
+test('refine own geodes', async () => {
+  const txRefine = await callContract(privateKey, gemRefineryContract, "BeginGeodeRefinement", [
+    param('quantity', 'Uint128', "500")
+  ], 0, false, false)
+  console.log(txRefine.id)
+  expect(txRefine.receipt.success).toEqual(true)
+
+  let gems = []
+  for (let i = 0; i < 10; i++) {
+    gems.push(
+        adt('Pair', ['String', `${gemRefineryAddress}.GemTier`], ['INT', adt(`${gemRefineryAddress}.TierC`, [], [])])
+    )
+  }
+
+  const txConcludeRefine = await callContract(privateKey, gemRefineryContract, "ConcludeRefinement", [
+    param('refinement_id', 'Uint256', "0"),
+    param('gems', `List (Pair String ${gemRefineryAddress}.GemTier)`, gems)
+  ], 0, false, false)
+  console.log(txConcludeRefine.id)
+  expect(txConcludeRefine.receipt.success).toEqual(true)
+
+  const itemsState = await itemsContract.getState()
+  console.log(`The state of the items contract is:\n${JSON.stringify(itemsState, null, 2)}`)
+})
+
+test('refine geodes when not enough balance', async () => {
+  const txRefine = await callContract(memberPrivateKey, gemRefineryContract, "BeginGeodeRefinement", [
+    param('quantity', 'Uint128', "500")
+  ], 0, false, false)
+  console.log(txRefine.id)
+  expect(txRefine.receipt.exceptions[0].message).toEqual(generateErrorMsg(2)) // throws CodeInsufficientFunds
+  expect(txRefine.receipt.success).toEqual(false)
+})
+
+test('enhance own gems', async () => {
+  const outputTier = adt(`${gemRefineryAddress}.TierB`, [], [])
+  const baseGemId = "1"
+  const materialGemsId = ["2", "3", "4"]
+  const txEnhance = await callContract(privateKey, gemRefineryContract, "BeginGemEnhancement", [
+    param('output_tier', `${gemRefineryAddress}.GemTier`, outputTier),
+    param('base_gem_token_id', 'Uint256', baseGemId),
+    param('material_gem_token_ids', 'List Uint256', materialGemsId)
+  ], 0, false, false)
+  console.log(txEnhance.id)
+  expect(txEnhance.receipt.success).toEqual(true)
+
+  let gems = []
+  for (let i = 0; i < 1; i++) {
+    gems.push(
+        adt('Pair', ['String', `${gemRefineryAddress}.GemTier`], ['INT', adt(`${gemRefineryAddress}.TierB`, [], [])])
+    )
+  }
+
+  const txConcludeRefine = await callContract(privateKey, gemRefineryContract, "ConcludeRefinement", [
+    param('refinement_id', 'Uint256', "1"),
+    param('gems', `List (Pair String ${gemRefineryAddress}.GemTier)`, gems)
+  ], 0, false, false)
+  console.log(txConcludeRefine.id)
+  expect(txConcludeRefine.receipt.success).toEqual(true)
+
+  const itemsState = await itemsContract.getState()
+  console.log(`The state of the items contract is:\n${JSON.stringify(itemsState, null, 2)}`)
+})
+
+test('enhance gem with other users gems', async () => {
+  const outputTier = adt(`${gemRefineryAddress}.TierB`, [], [])
+  const baseGemId = "5"
+  const materialGemsId = ["6", "7", "8"]
+  const txEnhance = await callContract(memberPrivateKey, gemRefineryContract, "BeginGemEnhancement", [
+    param('output_tier', `${gemRefineryAddress}.GemTier`, outputTier),
+    param('base_gem_token_id', 'Uint256', baseGemId),
+    param('material_gem_token_ids', 'List Uint256', materialGemsId)
+  ], 0, false, false)
+  console.log(txEnhance.id)
+  expect(txEnhance.receipt.exceptions[0].message).toEqual(generateErrorMsg(4)) // throws CodeNotOwnedGem
+  expect(txEnhance.receipt.success).toEqual(false)
+})
+
+test('refine geodes with insufficient huny', async () => {
+  const txMintGeode = await callContract(privateKey, geodeContract, "Mint", [
+    param('recipient', 'ByStr20', memberAddress),
+    param('amount', 'Uint128', '1000000')
+  ], 0, false, false)
+  console.log(txMintGeode.id)
+  expect(txMintGeode.receipt.success).toEqual(true)
+
+  const txRefine = await callContract(memberPrivateKey, gemRefineryContract, "BeginGeodeRefinement", [
+    param('quantity', 'Uint128', "500")
+  ], 0, false, false)
+  console.log(txRefine.id)
+  expect(txRefine.receipt.success).toEqual(true)
+  
+  let gems = []
+  for (let i = 0; i < 10; i++) {
+    gems.push(
+      adt('Pair', ['String', `${gemRefineryAddress}.GemTier`], ['INT', adt(`${gemRefineryAddress}.TierC`, [], [])])
+    )
+  }
+  
+  const txConcludeRefine = await callContract(privateKey, gemRefineryContract, "ConcludeRefinement", [
+    param('refinement_id', 'Uint256', "2"),
+    param('gems', `List (Pair String ${gemRefineryAddress}.GemTier)`, gems)
+  ], 0, false, false)
+  console.log(txConcludeRefine.id)
+  expect(txConcludeRefine.receipt.success).toEqual(false)
+  expect(txConcludeRefine.receipt.exceptions[0].message).toEqual(generateErrorMsg(2)) // throws CodeInsufficientFunds
+})
+
+test('enhance gems with insufficient huny', async () => {
+    let gems = []
+    for (let i = 0; i < 5; i++) {
+      const traits = [
+        adt('Pair', ['String', 'String'], ['Type', 'Gem']),
+        adt('Pair', ['String', 'String'], ['Affinity', 'INT']),
+        adt('Pair', ['String', 'String'], ['Tier', 'C']),
+      ]
+      const recipientUriPair = adt('Pair', ['ByStr20', 'String'], [memberAddress, 'test-enhance-without-huny'])
+      const recipientUriTraitsPair = adt('Pair', ['(Pair ByStr20 String)', '(List (Pair String String))'], [recipientUriPair, traits])
+      gems.push(recipientUriTraitsPair)
+    }
+
+    const txMintGem = await callContract(privateKey, itemsContract, "BatchMintAndSetTraits", [
+      param('to_token_uri_proposed_traits_list', 'List (Pair (Pair ByStr20 String) (List (Pair String String)))', gems)
+    ], 0, false, false)
+    console.log(txMintGem.id)
+    expect(txMintGem.receipt.success).toEqual(true)
+
+    const outputTier = adt(`${gemRefineryAddress}.TierB`, [], [])
+    const baseGemId = "12"
+    const materialGemsId = ["13", "14", "15"]
+    const txEnhance = await callContract(memberPrivateKey, gemRefineryContract, "BeginGemEnhancement", [
+      param('output_tier', `${gemRefineryAddress}.GemTier`, outputTier),
+      param('base_gem_token_id', 'Uint256', baseGemId),
+      param('material_gem_token_ids', 'List Uint256', materialGemsId)
+    ], 0, false, false)
+    console.log(txEnhance.id)
+    expect(txEnhance.receipt.success).toEqual(true)
+  
+    let enhancedGems = []
+    for (let i = 0; i < 1; i++) {
+      enhancedGems.push(
+          adt('Pair', ['String', `${gemRefineryAddress}.GemTier`], ['INT', adt(`${gemRefineryAddress}.TierB`, [], [])])
+      )
+    }
+  
+    const txConcludeRefine = await callContract(privateKey, gemRefineryContract, "ConcludeRefinement", [
+      param('refinement_id', 'Uint256', "3"),
+      param('gems', `List (Pair String ${gemRefineryAddress}.GemTier)`, enhancedGems)
+    ], 0, false, false)
+    console.log(txConcludeRefine.id)
+    expect(txConcludeRefine.receipt.success).toEqual(false)
+    expect(txConcludeRefine.receipt.exceptions[0].message).toEqual(generateErrorMsg(2)) // throws CodeInsufficientFunds
+})
+
+test('enhance gem C with insufficient base gems', async () => {
+  const outputTier = adt(`${gemRefineryAddress}.TierB`, [], [])
+  const baseGemId = "5"
+  const materialGemsId = ["6", "7"]
+  const txEnhance = await callContract(privateKey, gemRefineryContract, "BeginGemEnhancement", [
+    param('output_tier', `${gemRefineryAddress}.GemTier`, outputTier),
+    param('base_gem_token_id', 'Uint256', baseGemId),
+    param('material_gem_token_ids', 'List Uint256', materialGemsId)
+  ], 0, false, false)
+  console.log(txEnhance.id)
+  expect(txEnhance.receipt.success).toEqual(false)
+  expect(txEnhance.receipt.exceptions[0].message).toEqual(generateErrorMsg(11)) // throws CodeInvalidMaterial
+})
+
+test('enhance gem B with insufficient base gems', async () => {
+  let gems = []
+  for (let i = 0; i < 2; i++) {
+    const traits = [
+      adt('Pair', ['String', 'String'], ['Type', 'Gem']),
+      adt('Pair', ['String', 'String'], ['Affinity', 'INT']),
+      adt('Pair', ['String', 'String'], ['Tier', 'B']),
+    ]
+    const recipientUriPair = adt('Pair', ['ByStr20', 'String'], [address, 'test-enhance-without-enough-gems'])
+    const recipientUriTraitsPair = adt('Pair', ['(Pair ByStr20 String)', '(List (Pair String String))'], [recipientUriPair, traits])
+    gems.push(recipientUriTraitsPair)
+  }
+
+  const txMintGem = await callContract(privateKey, itemsContract, "BatchMintAndSetTraits", [
+    param('to_token_uri_proposed_traits_list', 'List (Pair (Pair ByStr20 String) (List (Pair String String)))', gems)
+  ], 0, false, false)
+  console.log(txMintGem.id)
+  expect(txMintGem.receipt.success).toEqual(true)
+
+  const outputTier = adt(`${gemRefineryAddress}.TierA`, [], [])
+  const baseGemId = "17"
+  const materialGemsId = ["18"]
+  const txEnhance = await callContract(privateKey, gemRefineryContract, "BeginGemEnhancement", [
+    param('output_tier', `${gemRefineryAddress}.GemTier`, outputTier),
+    param('base_gem_token_id', 'Uint256', baseGemId),
+    param('material_gem_token_ids', 'List Uint256', materialGemsId)
+  ], 0, false, false)
+  console.log(txEnhance.id)
+  expect(txEnhance.receipt.success).toEqual(false)
+  expect(txEnhance.receipt.exceptions[0].message).toEqual(generateErrorMsg(11)) // throws CodeInvalidMaterial
+})
+
+
+test('enhance gem A with insufficient base gems', async () => {
+  let gems = []
+  for (let i = 0; i < 1; i++) {
+    const traits = [
+      adt('Pair', ['String', 'String'], ['Type', 'Gem']),
+      adt('Pair', ['String', 'String'], ['Affinity', 'INT']),
+      adt('Pair', ['String', 'String'], ['Tier', 'A']),
+    ]
+    const recipientUriPair = adt('Pair', ['ByStr20', 'String'], [address, 'test-enhance-without-enough-gems'])
+    const recipientUriTraitsPair = adt('Pair', ['(Pair ByStr20 String)', '(List (Pair String String))'], [recipientUriPair, traits])
+    gems.push(recipientUriTraitsPair)
+  }
+
+  const txMintGem = await callContract(privateKey, itemsContract, "BatchMintAndSetTraits", [
+    param('to_token_uri_proposed_traits_list', 'List (Pair (Pair ByStr20 String) (List (Pair String String)))', gems)
+  ], 0, false, false)
+  console.log(txMintGem.id)
+  expect(txMintGem.receipt.success).toEqual(true)
+
+  const outputTier = adt(`${gemRefineryAddress}.TierS`, [], [])
+  const baseGemId = "19"
+  const materialGemsId = []
+  const txEnhance = await callContract(privateKey, gemRefineryContract, "BeginGemEnhancement", [
+    param('output_tier', `${gemRefineryAddress}.GemTier`, outputTier),
+    param('base_gem_token_id', 'Uint256', baseGemId),
+    param('material_gem_token_ids', 'List Uint256', materialGemsId)
+  ], 0, false, false)
+  console.log(txEnhance.id)
+  expect(txEnhance.receipt.success).toEqual(false)
+  expect(txEnhance.receipt.exceptions[0].message).toEqual(generateErrorMsg(11)) // throws CodeInvalidMaterial
+})
+
+
+test('enhance gem S with insufficient base gems', async () => {
+  let gems = []
+  for (let i = 0; i < 1; i++) {
+    const traits = [
+      adt('Pair', ['String', 'String'], ['Type', 'Gem']),
+      adt('Pair', ['String', 'String'], ['Affinity', 'INT']),
+      adt('Pair', ['String', 'String'], ['Tier', 'S']),
+    ]
+    const recipientUriPair = adt('Pair', ['ByStr20', 'String'], [address, 'test-enhance-without-enough-gems'])
+    const recipientUriTraitsPair = adt('Pair', ['(Pair ByStr20 String)', '(List (Pair String String))'], [recipientUriPair, traits])
+    gems.push(recipientUriTraitsPair)
+  }
+
+  const txMintGem = await callContract(privateKey, itemsContract, "BatchMintAndSetTraits", [
+    param('to_token_uri_proposed_traits_list', 'List (Pair (Pair ByStr20 String) (List (Pair String String)))', gems)
+  ], 0, false, false)
+  console.log(txMintGem.id)
+  expect(txMintGem.receipt.success).toEqual(true)
+
+  const outputTier = adt(`${gemRefineryAddress}.TierSS`, [], [])
+  const baseGemId = "20"
+  const materialGemsId = []
+  const txEnhance = await callContract(privateKey, gemRefineryContract, "BeginGemEnhancement", [
+    param('output_tier', `${gemRefineryAddress}.GemTier`, outputTier),
+    param('base_gem_token_id', 'Uint256', baseGemId),
+    param('material_gem_token_ids', 'List Uint256', materialGemsId)
+  ], 0, false, false)
+  console.log(txEnhance.id)
+  expect(txEnhance.receipt.success).toEqual(false)
+  expect(txEnhance.receipt.exceptions[0].message).toEqual(generateErrorMsg(11)) // throws CodeInvalidMaterial
+})

--- a/tests/zolar/mission-2/items.test.js
+++ b/tests/zolar/mission-2/items.test.js
@@ -1,0 +1,288 @@
+const { getAddressFromPrivateKey } = require("@zilliqa-js/zilliqa");
+const { getPrivateKey, param } = require("../../../scripts/zilliqa");
+const { createRandomAccount } = require("../../../scripts/account");
+const { callContract } = require("../../../scripts/call");
+const { deployItems, deployMetazoa } = require("../../../scripts/zolar/mission-2/helper");
+const { generateErrorMsg } = require('../bank/helper')
+
+let privateKey, memberPrivateKey, address, memberAddress, itemsAddress, itemsContract
+
+beforeAll(async () => {
+  // deploy metazoa
+  // deploy items
+  // mint metazoa
+  // mint items
+
+  // item checks
+  // equip item -> metazoa success
+  // unequip item <- metazoa success
+  // equip item -> item success
+  // unequip item <- item success
+  // equip an equipped item fail
+  // unequip an unequipped item fail
+  // equip item to itself fail
+  // equip item and try to transfer/burn it fail
+  // equip item where item does not belong to sender
+  // equip item where parent does not belong to sender
+  // equip item where, parent is already a child of the item attemping to equip
+  // equip item and transfer parent, check who can unequip it and check if item ownership changes
+
+
+  privateKey = getPrivateKey();
+  address = getAddressFromPrivateKey(privateKey).toLowerCase();
+
+  ; ({ key: memberPrivateKey, address: memberAddress } = await createRandomAccount(privateKey, '1000'))
+
+  metazoaContract = await deployMetazoa()
+  metazoaAddress = metazoaContract.address.toLowerCase();
+
+  itemsContract = await deployItems({ baseUri: "https://test-api.zolar.io/items/metadata/" });
+  itemsAddress = itemsContract.address.toLowerCase();
+
+  const txMintMetazoa = await callContract(privateKey, metazoaContract, "Mint", [
+    param('to', 'ByStr20', address),
+    param('token_uri', 'String', "testing mint metazoa")
+  ], 0, false, false)
+  console.log(txMintMetazoa.id)
+
+  const txMintItem1 = await callContract(privateKey, itemsContract, "Mint", [
+    param('to', 'ByStr20', address),
+    param('token_uri', 'String', "testing mint item 1")
+  ], 0, false, false)
+  console.log(txMintItem1.id)
+
+  const txMintItem2 = await callContract(privateKey, itemsContract, "Mint", [
+    param('to', 'ByStr20', address),
+    param('token_uri', 'String', "testing mint item 2")
+  ], 0, false, false)
+  console.log(txMintItem2.id)
+
+  const txMintItem3 = await callContract(privateKey, itemsContract, "Mint", [
+    param('to', 'ByStr20', address),
+    param('token_uri', 'String', "testing mint item 3")
+  ], 0, false, false)
+  console.log(txMintItem3.id)
+
+  const txMintItem4 = await callContract(privateKey, itemsContract, "Mint", [
+    param('to', 'ByStr20', memberAddress),
+    param('token_uri', 'String', "testing mint item 4")
+  ], 0, false, false)
+  console.log(txMintItem4.id)
+})
+
+test('equip and unequip item to and from metazoa', async () => {
+    const txEquip = await callContract(privateKey, itemsContract, "TransferToParent", [
+        param('item_id', 'Uint256', '1'),
+        param('to_token_id', 'Uint256', '1'),
+        param('to_contract', 'ByStr20', metazoaAddress)
+    ], 0, false, false)
+    console.log(txEquip.id)
+    expect(txEquip.receipt.success).toEqual(true)
+    
+    const txUnequip = await callContract(privateKey, itemsContract, "TransferFromParent", [
+        param('item_id', 'Uint256', '1'),
+        param('from_token_id', 'Uint256', '1'),
+        param('from_contract', 'ByStr20', metazoaAddress)
+    ], 0, false, false)
+    console.log(txUnequip.id)
+    expect(txUnequip.receipt.success).toEqual(true)
+})
+
+test('equip and unequip item to and from item', async () => {
+    const txEquip = await callContract(privateKey, itemsContract, "TransferToParent", [
+        param('item_id', 'Uint256', '1'),
+        param('to_token_id', 'Uint256', '2'),
+        param('to_contract', 'ByStr20', itemsAddress)
+    ], 0, false, false)
+    console.log(txEquip.id)
+    expect(txEquip.receipt.success).toEqual(true)
+    
+    const txUnequip = await callContract(privateKey, itemsContract, "TransferFromParent", [
+        param('item_id', 'Uint256', '1'),
+        param('from_token_id', 'Uint256', '2'),
+        param('from_contract', 'ByStr20', itemsAddress)
+    ], 0, false, false)
+    console.log(txUnequip.id)
+    expect(txUnequip.receipt.success).toEqual(true)
+})
+
+test('equipping an already equipped item', async () => {
+    const txEquip1 = await callContract(privateKey, itemsContract, "TransferToParent", [
+        param('item_id', 'Uint256', '1'),
+        param('to_token_id', 'Uint256', '2'),
+        param('to_contract', 'ByStr20', itemsAddress)
+    ], 0, false, false)
+    console.log(txEquip1.id)
+    expect(txEquip1.receipt.success).toEqual(true)
+    
+    const txEquip2 = await callContract(privateKey, itemsContract, "TransferToParent", [
+        param('item_id', 'Uint256', '1'),
+        param('to_token_id', 'Uint256', '2'),
+        param('to_contract', 'ByStr20', itemsAddress)
+    ], 0, false, false)
+    console.log(txEquip2.id)
+    expect(txEquip2.receipt.success).toEqual(false)
+    expect(txEquip2.receipt.exceptions[0].message).toEqual(generateErrorMsg(19)) // throws ItemOwnedError
+
+    const txUnequip = await callContract(privateKey, itemsContract, "TransferFromParent", [
+        param('item_id', 'Uint256', '1'),
+        param('from_token_id', 'Uint256', '2'),
+        param('from_contract', 'ByStr20', itemsAddress)
+    ], 0, false, false)
+    console.log(txUnequip.id)
+    expect(txUnequip.receipt.success).toEqual(true)
+})
+
+test('unequipping an unequipped item', async () => {
+    const txUnequip = await callContract(privateKey, itemsContract, "TransferFromParent", [
+        param('item_id', 'Uint256', '1'),
+        param('from_token_id', 'Uint256', '2'),
+        param('from_contract', 'ByStr20', itemsAddress)
+    ], 0, false, false)
+    console.log(txUnequip.id)
+    expect(txUnequip.receipt.success).toEqual(false)
+    expect(txUnequip.receipt.exceptions[0].message).toEqual(generateErrorMsg(20)) // throws ItemNotOwnedError
+})
+
+test('equipping item to itself', async () => {
+    const txEquip = await callContract(privateKey, itemsContract, "TransferToParent", [
+        param('item_id', 'Uint256', '1'),
+        param('to_token_id', 'Uint256', '1'),
+        param('to_contract', 'ByStr20', itemsAddress)
+    ], 0, false, false)
+    console.log(txEquip.id)
+    expect(txEquip.receipt.success).toEqual(false)
+    expect(txEquip.receipt.exceptions[0].message).toEqual(generateErrorMsg(34)) // throws ItemSelfError
+})
+
+test('transfer and burn an equipped item', async () => {
+    const txEquip = await callContract(privateKey, itemsContract, "TransferToParent", [
+        param('item_id', 'Uint256', '1'),
+        param('to_token_id', 'Uint256', '2'),
+        param('to_contract', 'ByStr20', itemsAddress)
+    ], 0, false, false)
+    console.log(txEquip.id)
+    expect(txEquip.receipt.success).toEqual(true)
+
+    const txTransfer = await callContract(privateKey, itemsContract, "TransferFrom", [
+        param('to', 'ByStr20', memberAddress),
+        param('token_id', 'Uint256', '1'),
+    ], 0, false, false)
+    console.log(txTransfer.id)
+    expect(txTransfer.receipt.success).toEqual(false)
+    expect(txTransfer.receipt.exceptions[0].message).toEqual(generateErrorMsg(19)) // throws ItemOwnedError
+
+    const txBurn = await callContract(privateKey, itemsContract, "Burn", [
+        param('token_id', 'Uint256', '1'),
+    ], 0, false, false)
+    console.log(txBurn.id)
+    expect(txBurn.receipt.success).toEqual(false)
+    expect(txBurn.receipt.exceptions[0].message).toEqual(generateErrorMsg(19)) // throws ItemOwnedError
+
+    const txUnequip = await callContract(privateKey, itemsContract, "TransferFromParent", [
+        param('item_id', 'Uint256', '1'),
+        param('from_token_id', 'Uint256', '2'),
+        param('from_contract', 'ByStr20', itemsAddress)
+    ], 0, false, false)
+    console.log(txUnequip.id)
+    expect(txUnequip.receipt.success).toEqual(true)
+})
+
+test('equip item that belongs to another user', async () => {
+    const txEquip = await callContract(privateKey, itemsContract, "TransferToParent", [
+        param('item_id', 'Uint256', '4'),
+        param('to_token_id', 'Uint256', '2'),
+        param('to_contract', 'ByStr20', itemsAddress)
+    ], 0, false, false)
+    console.log(txEquip.id)
+    expect(txEquip.receipt.success).toEqual(false)
+    expect(txEquip.receipt.exceptions[0].message).toEqual(generateErrorMsg(5)) // throws CodeNotTokenOwner
+})
+
+test('equip item where parent belongs to another user', async () => {
+    const txEquip = await callContract(privateKey, itemsContract, "TransferToParent", [
+        param('item_id', 'Uint256', '1'),
+        param('to_token_id', 'Uint256', '4'),
+        param('to_contract', 'ByStr20', itemsAddress)
+    ], 0, false, false)
+    console.log(txEquip.id)
+    expect(txEquip.receipt.success).toEqual(false)
+    expect(txEquip.receipt.exceptions[0].message).toEqual(generateErrorMsg(23)) // throws NotRootOwnerError
+})
+
+test('equip item where target parent is already a child of the item', async () => {
+    const txEquip1 = await callContract(privateKey, itemsContract, "TransferToParent", [
+        param('item_id', 'Uint256', '2'),
+        param('to_token_id', 'Uint256', '1'),
+        param('to_contract', 'ByStr20', itemsAddress)
+    ], 0, false, false)
+    console.log(txEquip1.id)
+    expect(txEquip1.receipt.success).toEqual(true)
+
+    const txEquip2 = await callContract(privateKey, itemsContract, "TransferToParent", [
+        param('item_id', 'Uint256', '3'),
+        param('to_token_id', 'Uint256', '2'),
+        param('to_contract', 'ByStr20', itemsAddress)
+    ], 0, false, false)
+    console.log(txEquip2.id)
+    expect(txEquip2.receipt.success).toEqual(true)
+
+    const txEquip3 = await callContract(privateKey, itemsContract, "TransferToParent", [
+        param('item_id', 'Uint256', '1'),
+        param('to_token_id', 'Uint256', '3'),
+        param('to_contract', 'ByStr20', itemsAddress)
+    ], 0, false, false)
+    console.log(txEquip3.id)
+    expect(txEquip3.receipt.success).toEqual(false)
+    expect(txEquip3.receipt.exceptions[0].message).toEqual(generateErrorMsg(29)) // throws ItemCannotBeParentError2
+
+    const txUnequip1 = await callContract(privateKey, itemsContract, "TransferFromParent", [
+        param('item_id', 'Uint256', '2'),
+        param('from_token_id', 'Uint256', '1'),
+        param('from_contract', 'ByStr20', itemsAddress)
+    ], 0, false, false)
+    console.log(txUnequip1.id)
+    expect(txUnequip1.receipt.success).toEqual(true)
+
+    const txUnequip2 = await callContract(privateKey, itemsContract, "TransferFromParent", [
+        param('item_id', 'Uint256', '3'),
+        param('from_token_id', 'Uint256', '2'),
+        param('from_contract', 'ByStr20', itemsAddress)
+    ], 0, false, false)
+    console.log(txUnequip2.id)
+    expect(txUnequip2.receipt.success).toEqual(true)
+})
+
+test('equip items and transfer parent, to check if ownership of child items is transferred too', async () => {
+    const txEquip = await callContract(privateKey, itemsContract, "TransferToParent", [
+        param('item_id', 'Uint256', '2'),
+        param('to_token_id', 'Uint256', '1'),
+        param('to_contract', 'ByStr20', itemsAddress)
+    ], 0, false, false)
+    console.log(txEquip.id)
+    expect(txEquip.receipt.success).toEqual(true)
+
+    const txTransfer = await callContract(privateKey, itemsContract, "TransferFrom", [
+        param('to', 'ByStr20', memberAddress),
+        param('token_id', 'Uint256', '1'),
+    ], 0, false, false)
+    console.log(txTransfer.id)
+    expect(txTransfer.receipt.success).toEqual(true)
+
+    const txUnequip1 = await callContract(privateKey, itemsContract, "TransferFromParent", [
+        param('item_id', 'Uint256', '2'),
+        param('from_token_id', 'Uint256', '1'),
+        param('from_contract', 'ByStr20', itemsAddress)
+    ], 0, false, false)
+    console.log(txUnequip1.id)
+    expect(txUnequip1.receipt.success).toEqual(false)
+    expect(txUnequip1.receipt.exceptions[0].message).toEqual(generateErrorMsg(23)) // throws NotRootOwnerError
+
+    const txUnequip2 = await callContract(memberPrivateKey, itemsContract, "TransferFromParent", [
+        param('item_id', 'Uint256', '2'),
+        param('from_token_id', 'Uint256', '1'),
+        param('from_contract', 'ByStr20', itemsAddress)
+    ], 0, false, false)
+    console.log(txUnequip2.id)
+    expect(txUnequip2.receipt.success).toEqual(true)
+})

--- a/tests/zolar/mission-2/quests.test.js
+++ b/tests/zolar/mission-2/quests.test.js
@@ -1,0 +1,160 @@
+const { getAddressFromPrivateKey } = require("@zilliqa-js/zilliqa");
+const { getPrivateKey, param } = require("../../../scripts/zilliqa");
+const { createRandomAccount } = require("../../../scripts/account");
+const { callContract, nextBlock } = require("../../../scripts/call");
+const { deployMetazoa, deployHunyToken, deployResource, deployQuest, ONE_HUNY } = require("../../../scripts/zolar/mission-2/helper");
+const { generateErrorMsg } = require('../bank/helper')
+
+let privateKey, memberPrivateKey, address, memberAddress, metazoaContract, metazoaAddress, hunyContract, hunyAddress, resourceContract, resourceAddress, questContract, questAddress
+
+beforeAll(async () => {
+  // deploy metazoa
+  // deploy huny
+  // deploy resource
+  // deploy quest
+  // mint metazoa
+  // add quest as minter for huny
+  // add quest as minter for resource
+  // add as operator
+
+  // quest checks
+  // enterQuest (metazoa_commanders update, last_harvested update, emit updateQuestBonus event, oracle trigger update)
+  // harvestResource (correct amt of resources, xp, huny minted/burnt based on blocks passed, emit updateQuestBonus, oracle trigger update)
+  // returnToBase (correct amt of resources, xp, huny minted/burnt based on blocks passed, emit updateQuestBonus, oracle trigger update, metazoa_commanders update)
+
+  privateKey = getPrivateKey();
+  address = getAddressFromPrivateKey(privateKey).toLowerCase();
+
+  ; ({ key: memberPrivateKey, address: memberAddress } = await createRandomAccount(privateKey, '1000'))
+
+  metazoaContract = await deployMetazoa()
+  metazoaAddress = metazoaContract.address.toLowerCase();
+
+  hunyContract = await deployHunyToken({ name: "Huny Token", symbol: "HUNY", decimals: "12" });
+  hunyAddress = hunyContract.address.toLowerCase();
+
+  resourceContract = await deployResource("ZolarGeode", { name: "Geode - Zolar Resource", symbol: "zlrGEODE", decimals: "2" });
+  resourceAddress = resourceContract.address.toLowerCase();
+
+  questContract = await deployQuest({
+    questName: "Zolar Quest - Asteroid Belt",
+    resourceContract: resourceAddress,
+    metazoaContract: metazoaAddress,
+    epoch: "1",
+    resourcePerEpoch: "2800",
+    xpPerEpoch: "5",
+    feeContract: hunyAddress,
+    harvestFee: ONE_HUNY.times(100), // 100 HUNY
+    returnFee: ONE_HUNY.times(200), // 200 HUNY
+  });
+  questAddress = questContract.address.toLowerCase();
+
+  const txMintMetazoa1 = await callContract(privateKey, metazoaContract, "Mint", [
+    param('to', 'ByStr20', address),
+    param('token_uri', 'String', "testing mint metazoa")
+  ], 0, false, false)
+  console.log(txMintMetazoa1.id)
+
+  const txMintMetazoa2 = await callContract(privateKey, metazoaContract, "Mint", [
+    param('to', 'ByStr20', memberAddress),
+    param('token_uri', 'String', "testing mint metazoa")
+  ], 0, false, false)
+  console.log(txMintMetazoa2.id)
+
+  const txAddMinterHuny = await callContract(privateKey, hunyContract, "AddMinter", [
+    param('minter', 'ByStr20', questAddress),
+  ], 0, false, false)
+  console.log(txAddMinterHuny.id)
+
+  const txAddMinterResource = await callContract(privateKey, resourceContract, "AddMinter", [
+    param('minter', 'ByStr20', questAddress),
+  ], 0, false, false)
+  console.log(txAddMinterResource.id)
+
+  const txAddOperator1 = await callContract(privateKey, metazoaContract, "AddOperator", [
+    param('operator', 'ByStr20', questAddress),
+  ], 0, false, false)
+  console.log(txAddOperator1.id)
+
+  const txAddOperator2 = await callContract(memberPrivateKey, metazoaContract, "AddOperator", [
+    param('operator', 'ByStr20', questAddress),
+  ], 0, false, false)
+  console.log(txAddOperator2.id)
+})
+
+test('enter quest with owned metazoas', async () => {
+  const txEnterQuest = await callContract(privateKey, questContract, "EnterQuest", [
+    param('token_ids', 'List Uint256', ["1"]),
+  ], 0, false, false)
+  console.log(txEnterQuest.id)
+  expect(txEnterQuest.receipt.success).toEqual(true)
+})
+
+test('enter quest with other users metazoas', async () => {
+  const txEnterQuest = await callContract(privateKey, questContract, "EnterQuest", [
+    param('token_ids', 'List Uint256', ["2"]),
+  ], 0, false, false)
+  console.log(txEnterQuest.id)
+  expect(txEnterQuest.receipt.success).toEqual(false)
+  expect(txEnterQuest.receipt.exceptions[0].message).toEqual(generateErrorMsg(5)) // throws CodeNotTokenOwner
+})
+
+test('harvest with owned metazoas', async () => {
+  const txHarvest = await callContract(privateKey, questContract, "HarvestResource", [
+    param('token_ids', 'List Uint256', ["1"]),
+  ], 0, false, false)
+  console.log(txHarvest.id)
+  expect(txHarvest.receipt.success).toEqual(true)
+})
+
+test('harvest with other users metazoas', async () => {
+  const txEnterQuest = await callContract(memberPrivateKey, questContract, "EnterQuest", [
+    param('token_ids', 'List Uint256', ["2"]),
+  ], 0, false, false)
+  console.log(txEnterQuest.id)
+  expect(txEnterQuest.receipt.success).toEqual(true)
+
+  const txHarvest = await callContract(privateKey, questContract, "HarvestResource", [
+    param('token_ids', 'List Uint256', ["2"]),
+  ], 0, false, false)
+  console.log(txHarvest.id)
+  expect(txHarvest.receipt.success).toEqual(false)
+  expect(txHarvest.receipt.exceptions[0].message).toEqual(generateErrorMsg(5)) // throws CodeNotTokenOwner
+})
+
+test('return to base with owned metazoas', async () => {
+  const txReturn = await callContract(privateKey, questContract, "ReturnToBase", [
+    param('token_ids', 'List Uint256', ["1"]),
+  ], 0, false, false)
+  console.log(txReturn.id)
+  expect(txReturn.receipt.success).toEqual(true)
+})
+
+test('return to base with other users metazoas', async () => {
+  const txReturn = await callContract(privateKey, questContract, "ReturnToBase", [
+    param('token_ids', 'List Uint256', ["2"]),
+  ], 0, false, false)
+  console.log(txReturn.id)
+  expect(txReturn.receipt.success).toEqual(false)
+  expect(txReturn.receipt.exceptions[0].message).toEqual(generateErrorMsg(5)) // throws CodeNotTokenOwner
+})
+
+test('return to base without enough huny for fees', async () => {
+  const txReturn = await callContract(memberPrivateKey, questContract, "ReturnToBase", [
+    param('token_ids', 'List Uint256', ["2"]),
+  ], 0, false, false)
+  console.log(txReturn.id)
+  expect(txReturn.receipt.success).toEqual(false)
+  expect(txReturn.receipt.exceptions[0].message).toEqual(generateErrorMsg(2)) // throws CodeInsufficientFunds
+})
+
+test('harvest without enough huny for fees', async () => {
+  await nextBlock()
+  await nextBlock()
+  const txHarvest = await callContract(memberPrivateKey, questContract, "HarvestResource", [
+    param('token_ids', 'List Uint256', ["2"]),
+  ], 0, false, false)
+  console.log(txHarvest.id)
+  expect(txHarvest.receipt.success).toEqual(false)
+  expect(txHarvest.receipt.exceptions[0].message).toEqual(generateErrorMsg(2)) // throws CodeInsufficientFunds
+})


### PR DESCRIPTION
- add tests for `QuestContract`, `ItemsContract`, and `GemRefineryContract`
- update test for `ZOMGStoreContract` to include `VerifyOwnership` test
- minor bug fix to fee charging of `GemRefineryContract`
- minor tweak to `RequireAccessToTransfer` procedure of `ItemsContract` (checks if is consumer as well, apart from operator/spender/tokenOwner)