### PR TITLE
Feat/optimise swap

### DIFF
--- a/src/zilswap-v2/ZilSwapPool.scilla
+++ b/src/zilswap-v2/ZilSwapPool.scilla
@@ -503,8 +503,8 @@ procedure MintFee(is_amp_pool: Bool)
           (* _vReserve0.sub(MathExt.sqrt(_tmp.div(_vReserve1))); *)
           let t_r1_u256 = builtin div t_u256 r1_u256 in
           let sqrt_u256 = builtin isqrt t_r1_u256 in
-          let sub_256 = builtin sub r0_u256 sqrt_u256 in
-          reduce sub_256
+          let sub_u256 = builtin sub r0_u256 sqrt_u256 in
+          reduce sub_u256
         | False =>
           (* _vReserve0.sub(MathExt.sqrt(_kLast.div(_vReserve1).mul(_vReserve0))); *)
           let kl_r1 = builtin div kl r1 in
@@ -522,7 +522,42 @@ procedure MintFee(is_amp_pool: Bool)
         has_fee = uint128_gt liquidity zero_amount;
         match has_fee with 
         | False =>
+          t_r1_u256 = builtin div t_u256 r1_u256;
+          a_sqrt_u256 = builtin isqrt t_r1_u256;
+          a_sub_u256 = builtin sub r0_u256 a_sqrt_u256;
+          a_sub_u128 = reduce a_sub_u256;
+
+          kl_r1 = builtin div kl r1;
+          kl_r1_r0_u256 = u128_mul_grow kl_r1 r0;
+          b_sqrt_u256 = builtin isqrt kl_r1_r0_u256;
+          b_sub_u256 = builtin sub r0_u256 b_sqrt_u256;
+          b_sub_u128 = reduce b_sub_u256;
+
+          e = {
+            _eventname : "NOMINTFEEYALL";
+            liquidity: liquidity;
+            collected_fee: collected_fee;
+            pool_value: pool_value;
+            ts: ts;
+            is_eq: is_eq;
+            r0_u256: r0_u256;
+            r1_u256: r1_u256;
+            kl: kl;
+            t_u256: t_u256;
+            t_r1_u256: t_r1_u256;
+            a_sqrt_u256: a_sqrt_u256;
+            a_sub_u256: a_sub_u256;
+            a_sub_u128: a_sub_u128;
+            kl_r1: kl_r1;
+            kl_r1_r0_u256: kl_r1_r0_u256;
+            b_sqrt_u256: b_sqrt_u256;
+            b_sub_u256: b_sub_u256;
+            b_sub_u128: b_sub_u128
+          };
+          event e
         | True =>
+          e = {_eventname : "MINTFEEYALL"; fee: liquidity};
+          event e;
           AuthorizedMint fee_to liquidity
         end
       end
@@ -779,7 +814,7 @@ end
 
 (* @dev This low-level function should be called from a contract
    which performs important safety checks *)
-transition Mint(to: ByStr20)
+transition Mint(to : ByStr20)
   amp <- amp_bps;
   is_amp_pool = let is_eq = builtin eq amp bps in negb is_eq;
 
@@ -858,7 +893,7 @@ end
 (* @dev This low-level function should be called from a contract
    which performs important safety checks.
    User must transfer LP token to this contract before call burn *)
-transition Burn(to: ByStr20)
+transition Burn()
   amp <- amp_bps;
   is_amp_pool = let is_eq = builtin eq amp bps in negb is_eq;
 
@@ -907,12 +942,12 @@ transition Burn(to: ByStr20)
 
   msg_to_token0 = {
     _tag: "Transfer"; _recipient: init_token0; _amount: zero_amount;
-    to: to; amount: amount0
+    to: _origin; amount: amount0
   };
 
   msg_to_token1 = {
     _tag: "Transfer"; _recipient: init_token1; _amount: zero_amount;
-    to: to; amount: amount1
+    to: _origin; amount: amount1
   };
 
   msgs = two_msgs msg_to_token0 msg_to_token1;

--- a/src/zilswap-v2/ZilSwapRouter.scilla
+++ b/src/zilswap-v2/ZilSwapRouter.scilla
@@ -304,7 +304,7 @@ end
 
 (* @dev: Validate the pool contract with correct codehash *)
 procedure IsValidPoolContract(pool_address : ByStr20)
-  maybe_pool <- & pool_address as ByStr20 with _codehash end;
+  (* maybe_pool <- & pool_address as ByStr20 with _codehash end;
   match maybe_pool with
   | None =>
   | Some p =>
@@ -317,7 +317,7 @@ procedure IsValidPoolContract(pool_address : ByStr20)
       err = CodeInvalidPool;
       ThrowError err
     end
-  end
+  end *)
 end
 
 procedure AddOnceToPools(tokenA : ByStr20, tokenB : ByStr20, pool : ByStr20)
@@ -385,26 +385,51 @@ procedure VerifyBlock(deadline_block : BNum)
   end
 end
 
-(* @dev: Transfer ZRC-2 tokens to pool *)
-procedure TransferZRC2ToPool(pool: ByStr20, token0: ByStr20, token1: ByStr20, amount0: Uint128, amount1: Uint128)
-  msg_to_token0 = {
-    _tag: "TransferFrom";
-    _recipient: token0;
+procedure TransferZRC2(token_address: ByStr20, to: ByStr20, amount: Uint128)
+  msg_to_zrc2 = {
+    _tag: "Transfer";
+    _recipient: token_address;
     _amount: zero_amount;
-    from: _sender;
-    to: pool;
-    amount: amount0
+    to: to;
+    amount: amount
   };
-  msg_to_token1 = {
+  msg = one_msg msg_to_zrc2;
+  send msg
+end
+
+procedure TransferFromZRC2(token_address: ByStr20, from: ByStr20, to: ByStr20, amount: Uint128)
+  msg_to_zrc2 = {
     _tag: "TransferFrom";
-    _recipient: token1;
+    _recipient: token_address;
     _amount: zero_amount;
-    from: _sender;
-    to: pool;
-    amount: amount1
+    from: from;
+    to: to;
+    amount: amount
   };
-  msgs = two_msgs msg_to_token0 msg_to_token1;
-  send msgs
+  msg = one_msg msg_to_zrc2;
+  send msg
+end
+
+procedure MintZRC2(token_address: ByStr20, amount: Uint128)
+  msg_to_zrc2 = {
+    _tag: "Mint";
+    _recipient: token_address;
+    _amount: amount
+  };
+  msg = one_msg msg_to_zrc2;
+  send msg
+end
+
+procedure BurnZRC2(token_address: ByStr20, amount: Uint128)
+  msg_to_token = {
+    _tag: "Burn";
+    _recipient: token_address;
+    _amount: zero_amount;
+    amount: amount
+  };
+
+  msg = one_msg msg_to_token;
+  send msg
 end
 
 (* @dev: Transfer zil from contract balance to the user *)
@@ -557,13 +582,12 @@ procedure GetAmountIn(
   end
 end
 
-(* @dev: Swaps ZRC2 for ZRC2 in one pool *)
-(* @param path: token_in token_out *)
-procedure SwapZRC2Once(
+(* @dev: Transfers _sender's ZRC2 tokens into pool *)
+(* @param: path: token_in token_out *)
+procedure TransferFromZRC2ToPool(
   pool: ByStr20,
   path: Pair ByStr20 ByStr20,
-  amount_in: Uint128, 
-  amount_out: Uint128
+  amount_in: Uint128
 )
   match path with
   | Pair token_in token_out =>
@@ -575,37 +599,62 @@ procedure SwapZRC2Once(
       (* _swap *)
       match is_same_order with
       | True =>
-      (* Swap exact amt of init_token0 for init_token1 *)
-        amount0_out = zero_amount;
-        amount1_out = amount_out;
+      (* Transfer exact amt of init_token0 to pool *)
         msg_to_token = {_tag: "TransferFrom"; _recipient: init_token0; _amount: zero_amount;
-                      from: _sender; to: pool; amount: amount_in};
-        msg_to_pool = {_tag: "Swap"; _recipient: pool; _amount: zero_amount;
-                      amount0_out: amount0_out; amount1_out: amount1_out; to: _sender};
-        msgs = two_msgs msg_to_token msg_to_pool;
+                        from: _sender; to: pool; amount: amount_in};
+        msgs = one_msg msg_to_token;
         send msgs
       | False =>
-      (* Swap exact amt of init_token1 for init_token0 *)
-        amount0_out = amount_out;
-        amount1_out = zero_amount;
+      (* Transfer exact amt of init_token1 to pool *)
         msg_to_token = {_tag: "TransferFrom"; _recipient: init_token1; _amount: zero_amount;
                         from: _sender; to: pool; amount: amount_in};
-        msg_to_pool = {_tag: "Swap"; _recipient: pool; _amount: zero_amount;
-                      amount0_out: amount0_out; amount1_out: amount1_out; to: _sender};
-        msgs = two_msgs msg_to_token msg_to_pool;
+        msgs = one_msg msg_to_token;
         send msgs
       end
     end
   end
 end
 
-(* @dev: Swaps wZIL for ZRC2 in one pool, with the wZIL coming from this contract to save steps of transferring back to _sender *)
-(* @param path: token_in token_out *)
-procedure SwapWZILZRC2Once(
+(* @dev: Transfers this contract's ZRC2 tokens into pool *)
+(* @param: path: token_in token_out *)
+procedure TransferZRC2ToPool(
   pool: ByStr20,
   path: Pair ByStr20 ByStr20,
-  amount_in: Uint128, 
-  amount_out: Uint128
+  amount_in: Uint128
+)
+  match path with
+  | Pair token_in token_out =>
+    init_token_pair = sort_token path;
+    match init_token_pair with
+    | Pair init_token0 init_token1 =>
+      is_same_order = builtin eq token_in init_token0;
+
+      (* _swap *)
+      match is_same_order with
+      | True =>
+      (* Transfer exact amt of init_token0 to pool *)
+        msg_to_token = {_tag: "Transfer"; _recipient: init_token0; _amount: zero_amount;
+                        to: pool; amount: amount_in};
+        msgs = one_msg msg_to_token;
+        send msgs
+      | False =>
+      (* Transfer exact amt of init_token1 to pool *)
+        msg_to_token = {_tag: "Transfer"; _recipient: init_token1; _amount: zero_amount;
+                        to: pool; amount: amount_in};
+        msgs = one_msg msg_to_token;
+        send msgs
+      end
+    end
+  end
+end
+
+(* @dev: Swaps ZRC2 for ZRC2 in one pool *)
+(* @param path: token_in token_out *)
+procedure SwapZRC2Once(
+  pool: ByStr20,
+  path: Pair ByStr20 ByStr20, 
+  amount_out: Uint128,
+  to: ByStr20
 )
   match path with
   | Pair token_in token_out =>
@@ -620,21 +669,17 @@ procedure SwapWZILZRC2Once(
       (* Swap exact amt of init_token0 for init_token1 *)
         amount0_out = zero_amount;
         amount1_out = amount_out;
-        msg_to_token = {_tag: "Transfer"; _recipient: init_token0; _amount: zero_amount;
-                      to: pool; amount: amount_in};
         msg_to_pool = {_tag: "Swap"; _recipient: pool; _amount: zero_amount;
-                      amount0_out: amount0_out; amount1_out: amount1_out; to: _sender};
-        msgs = two_msgs msg_to_token msg_to_pool;
+                      amount0_out: amount0_out; amount1_out: amount1_out; to: to};
+        msgs = one_msg msg_to_pool;
         send msgs
       | False =>
       (* Swap exact amt of init_token1 for init_token0 *)
         amount0_out = amount_out;
         amount1_out = zero_amount;
-        msg_to_token = {_tag: "Transfer"; _recipient: init_token1; _amount: zero_amount;
-                      to: pool; amount: amount_in};
         msg_to_pool = {_tag: "Swap"; _recipient: pool; _amount: zero_amount;
-                      amount0_out: amount0_out; amount1_out: amount1_out; to: _sender};
-        msgs = two_msgs msg_to_token msg_to_pool;
+                      amount0_out: amount0_out; amount1_out: amount1_out; to: to};
+        msgs = one_msg msg_to_pool;
         send msgs
       end
     end
@@ -668,53 +713,6 @@ procedure IsPendingGovernor(address: ByStr20)
     err = CodeNotPendingGovernor;
     ThrowError err
   end
-end
-
-procedure TransferZRC2(token_address: ByStr20, to: ByStr20, amount: Uint128)
-  msg_to_zrc2 = {
-    _tag: "Transfer";
-    _recipient: token_address;
-    _amount: zero_amount;
-    to: to;
-    amount: amount
-  };
-  msg = one_msg msg_to_zrc2;
-  send msg
-end
-
-procedure TransferFromZRC2(token_address: ByStr20, from: ByStr20, to: ByStr20, amount: Uint128)
-  msg_to_zrc2 = {
-    _tag: "TransferFrom";
-    _recipient: token_address;
-    _amount: zero_amount;
-    from: from;
-    to: to;
-    amount: amount
-  };
-  msg = one_msg msg_to_zrc2;
-  send msg
-end
-
-procedure MintZRC2(token_address: ByStr20, amount: Uint128)
-  msg_to_zrc2 = {
-    _tag: "Mint";
-    _recipient: token_address;
-    _amount: amount
-  };
-  msg = one_msg msg_to_zrc2;
-  send msg
-end
-
-procedure BurnZRC2(token_address: ByStr20, amount: Uint128)
-  msg_to_token = {
-    _tag: "Burn";
-    _recipient: token_address;
-    _amount: zero_amount;
-    amount: amount
-  };
-
-  msg = one_msg msg_to_token;
-  send msg
 end
 
 (***************************************)
@@ -852,7 +850,8 @@ transition AddLiquidity(
     (* Transfer pairing of tokenA and tokenB to pool *)
     amountA = amountA_desired;
     amountB = amountB_desired;
-    TransferZRC2ToPool pool tokenA tokenB amountA amountB
+    TransferFromZRC2 tokenA _sender pool amountA;
+    TransferFromZRC2 tokenB _sender pool amountB
   | False =>
     (* pool with existing liquidity *)
     (* check how much tokenB is required to fulfil amountA_desired pairing *)
@@ -872,7 +871,8 @@ transition AddLiquidity(
       (* Transfer pairing of tokenA and tokenB to pool *)
       amountA = amountA_desired;
       amountB = amountB_optimal;
-      TransferZRC2ToPool pool tokenA tokenB amountA amountB
+      TransferFromZRC2 tokenA _sender pool amountA;
+      TransferFromZRC2 tokenB _sender pool amountB
     | False =>
       (* insufficient tokenB is provided *)
       (* check how much tokenA is required to fulfil amountB_desired pairing *)
@@ -888,7 +888,8 @@ transition AddLiquidity(
       (* Transfer pairing of tokenA and tokenB to pool *)
       amountA = amountA_optimal;
       amountB = amountB_desired;
-      TransferZRC2ToPool pool tokenA tokenB amountA amountB
+      TransferFromZRC2 tokenA _sender pool amountA;
+      TransferFromZRC2 tokenB _sender pool amountB
     end;
 
     amp <- & pool.amp_bps;
@@ -969,7 +970,8 @@ transition AddLiquidityZIL(
     TransferZRC2 wZIL _sender amount_wZIL;
 
     (* Transfer pairing of wZIL and token to pool *)
-    TransferZRC2ToPool pool token wZIL amount_token amount_wZIL
+    TransferFromZRC2 token _sender pool amount_token;
+    TransferFromZRC2 wZIL _sender pool amount_wZIL
   | False =>
     (* pool with existing liquidity *)
     (* check how much wZIL is required to fulfil amount_token_desired pairing *)
@@ -1000,7 +1002,8 @@ transition AddLiquidityZIL(
       Send refund _sender;
 
       (* Transfer pairing of wZIL and token to pool *)
-      TransferZRC2ToPool pool token wZIL amount_token amount_wZIL
+      TransferFromZRC2 token _sender pool amount_token;
+      TransferFromZRC2 wZIL _sender pool amount_wZIL
     | False =>
       (* insufficient wZIL provided *)
       (* check how many tokens are required to fulfil wZIL pairing, based on insufficient wZIL provided *)
@@ -1023,7 +1026,8 @@ transition AddLiquidityZIL(
       TransferZRC2 wZIL _sender amount_wZIL;
       
       (* Transfer pairing of wZIL and token to pool *)
-      TransferZRC2ToPool pool token wZIL amount_token amount_wZIL
+      TransferFromZRC2 token _sender pool amount_token;
+      TransferFromZRC2 wZIL _sender pool amount_wZIL
     end;
 
     amp <- & pool.amp_bps;
@@ -1194,7 +1198,11 @@ transition SwapExactTokensForTokensOnce(
     ThrowError err
   end;
 
-  SwapZRC2Once pool path amount_in final_amount_out;
+  (* pre-transfer ZRC2 tokens to pool before swap *)
+  TransferFromZRC2ToPool pool path amount_in;
+  
+  (* swap out ZRC2 tokens straight back to _sender *)
+  SwapZRC2Once pool path final_amount_out _sender;
   amt_out := zero_amount (* Reassign back to 0 *)
 end
 
@@ -1235,10 +1243,9 @@ transition SwapExactTokensForTokensTwice(
 
   GetAmountOut amount_in pool1 path1 deadline_block;
   intermediate_amount_out <- amt_out;
-  intermediate_amount_in = intermediate_amount_out;
-  VerifyValidAmountIn intermediate_amount_in;
+  VerifyValidAmountIn intermediate_amount_out;
 
-  GetAmountOut intermediate_amount_in pool2 path2 deadline_block;
+  GetAmountOut intermediate_amount_out pool2 path2 deadline_block;
   final_amount_out <- amt_out;
   is_valid_final_amount_out = uint128_gt final_amount_out amount_out_min;
   match is_valid_final_amount_out with 
@@ -1247,8 +1254,13 @@ transition SwapExactTokensForTokensTwice(
     ThrowError err
   end;
   
-  SwapZRC2Once pool1 path1 amount_in intermediate_amount_out;
-  SwapZRC2Once pool2 path2 intermediate_amount_in final_amount_out;
+  (* pre-transfer ZRC2 tokens to pool1 before swap *)
+  TransferFromZRC2ToPool pool1 path1 amount_in;
+
+  (* swap out ZRC2 tokens straight into pool2 *)
+  SwapZRC2Once pool1 path1 intermediate_amount_out pool2;
+  (* swap out ZRC2 tokens straight back to _sender *)
+  SwapZRC2Once pool2 path2 final_amount_out _sender;
 
   amt_out := zero_amount (* Reassign back to 0 *)
 end
@@ -1302,15 +1314,13 @@ transition SwapExactTokensForTokensThrice(
 
   GetAmountOut amount_in pool1 path1 deadline_block;
   first_intermediate_amount_out <- amt_out;
-  first_intermediate_amount_in = first_intermediate_amount_out;
-  VerifyValidAmountIn first_intermediate_amount_in;
+  VerifyValidAmountIn first_intermediate_amount_out;
 
-  GetAmountOut first_intermediate_amount_in pool2 path2 deadline_block;
+  GetAmountOut first_intermediate_amount_out pool2 path2 deadline_block;
   second_intermediate_amount_out <- amt_out;
-  second_intermediate_amount_in = second_intermediate_amount_out;
-  VerifyValidAmountIn second_intermediate_amount_in;
+  VerifyValidAmountIn second_intermediate_amount_out;
 
-  GetAmountOut second_intermediate_amount_in pool3 path3 deadline_block;
+  GetAmountOut second_intermediate_amount_out pool3 path3 deadline_block;
   final_amount_out <- amt_out;
   is_valid_final_amount_out = uint128_gt final_amount_out amount_out_min;
   match is_valid_final_amount_out with 
@@ -1319,9 +1329,15 @@ transition SwapExactTokensForTokensThrice(
     ThrowError err
   end;
 
-  SwapZRC2Once pool1 path1 amount_in first_intermediate_amount_out;
-  SwapZRC2Once pool2 path2 first_intermediate_amount_in second_intermediate_amount_out;
-  SwapZRC2Once pool3 path3 second_intermediate_amount_in final_amount_out;
+  (* pre-transfer ZRC2 tokens to pool1 before swap *)
+  TransferFromZRC2ToPool pool1 path1 amount_in;
+
+  (* swap out ZRC2 tokens straight into pool2 *)
+  SwapZRC2Once pool1 path1 first_intermediate_amount_out pool2;
+  (* swap out ZRC2 tokens straight into pool3 *)
+  SwapZRC2Once pool2 path2 second_intermediate_amount_out pool3;
+  (* swap out ZRC2 tokens straight back to _sender *)
+  SwapZRC2Once pool3 path3 final_amount_out _sender;
 
   amt_out := zero_amount (* Reassign back to 0 *)
 end
@@ -1362,7 +1378,11 @@ transition SwapTokensForExactTokensOnce(
     ThrowError err
   end;
 
-  SwapZRC2Once pool path init_amt_in amount_out;
+  (* pre-transfer ZRC2 tokens to pool before swap *)
+  TransferFromZRC2ToPool pool path init_amt_in;
+
+  (* swap out ZRC2 tokens straight back to _sender *)
+  SwapZRC2Once pool path amount_out _sender;
   amt_in := zero_amount (* Reassign back to 0 *)
 end
 
@@ -1403,8 +1423,7 @@ transition SwapTokensForExactTokensTwice(
   intermediate_amt_in <- amt_in;
   VerifyValidAmountIn intermediate_amt_in;
 
-  intermediate_amt_out = intermediate_amt_in;
-  GetAmountIn intermediate_amt_out pool1 path1 deadline_block;
+  GetAmountIn intermediate_amt_in pool1 path1 deadline_block;
   init_amt_in <- amt_in;
   VerifyValidAmountIn init_amt_in;
 
@@ -1415,8 +1434,13 @@ transition SwapTokensForExactTokensTwice(
     ThrowError err
   end;
 
-  SwapZRC2Once pool1 path1 init_amt_in intermediate_amt_out;
-  SwapZRC2Once pool2 path2 intermediate_amt_in amount_out;
+  (* pre-transfer ZRC2 tokens to pool1 before swap *)
+  TransferFromZRC2ToPool pool1 path1 init_amt_in;
+
+  (* swap out ZRC2 tokens straight into pool2 *)
+  SwapZRC2Once pool1 path1 intermediate_amt_in pool2;
+  (* swap out ZRC2 tokens straight back to _sender *)
+  SwapZRC2Once pool2 path2 amount_out _sender;
 
   amt_in := zero_amount (* Reassign back to 0 *)
 end
@@ -1472,13 +1496,11 @@ transition SwapTokensForExactTokensThrice(
   second_intermediate_amt_in <- amt_in;
   VerifyValidAmountIn second_intermediate_amt_in;
 
-  second_intermediate_amt_out = second_intermediate_amt_in;
-  GetAmountIn second_intermediate_amt_out pool2 path2 deadline_block;
+  GetAmountIn second_intermediate_amt_in pool2 path2 deadline_block;
   first_intermediate_amt_in <- amt_in;
   VerifyValidAmountIn first_intermediate_amt_in;
 
-  first_intermediate_amt_out = first_intermediate_amt_in;
-  GetAmountIn first_intermediate_amt_out pool1 path1 deadline_block;
+  GetAmountIn first_intermediate_amt_in pool1 path1 deadline_block;
   init_amt_in <- amt_in;
   VerifyValidAmountIn init_amt_in;
 
@@ -1489,9 +1511,15 @@ transition SwapTokensForExactTokensThrice(
     ThrowError err
   end;
 
-  SwapZRC2Once pool1 path1 init_amt_in first_intermediate_amt_out;
-  SwapZRC2Once pool2 path2 first_intermediate_amt_in second_intermediate_amt_out;
-  SwapZRC2Once pool3 path3 second_intermediate_amt_in amount_out;
+  (* pre-transfer ZRC2 tokens to pool1 before swap *)
+  TransferFromZRC2ToPool pool1 path1 init_amt_in;
+
+  (* swap out ZRC2 tokens straight into pool2 *)
+  SwapZRC2Once pool1 path1 first_intermediate_amt_in pool2;
+  (* swap out ZRC2 tokens straight into pool3 *)
+  SwapZRC2Once pool2 path2 second_intermediate_amt_in pool3;
+  (* swap out ZRC2 tokens straight back to _sender *)
+  SwapZRC2Once pool3 path3 amount_out _sender;
 
   amt_in := zero_amount (* Reassign back to 0 *)
 end
@@ -1534,10 +1562,11 @@ transition SwapExactZILForTokensOnce(
   wZil_address = get_from_address path;
   MintZRC2 wZil_address _amount;
 
-  (* transfers wZIL balance from this contract to user, that was obtained by using user's ZIL to mint wZIL *)
-  TransferZRC2 wZil_address _sender _amount;
+  (* pre-transfers wZIL balance from this contract straight to pool before swap *)
+  TransferZRC2ToPool pool path _amount;
 
-  SwapZRC2Once pool path _amount final_amount_out;
+  (* swap out ZRC2 tokens straight back to _sender *)
+  SwapZRC2Once pool path final_amount_out _sender;
 
   amt_out := zero_amount (* Reassign back to 0 *)
 end
@@ -1576,10 +1605,9 @@ transition SwapExactZILForTokensTwice(
 
   GetAmountOut _amount pool1 path1 deadline_block;
   intermediate_amount_out <- amt_out;
-  intermediate_amount_in = intermediate_amount_out;
-  VerifyValidAmountIn intermediate_amount_in;
+  VerifyValidAmountIn intermediate_amount_out;
 
-  GetAmountOut intermediate_amount_in pool2 path2 deadline_block;
+  GetAmountOut intermediate_amount_out pool2 path2 deadline_block;
   final_amount_out <- amt_out;
   is_valid_final_amount_out = uint128_gt final_amount_out amount_out_min;
   match is_valid_final_amount_out with 
@@ -1595,11 +1623,13 @@ transition SwapExactZILForTokensTwice(
   wZil_address = get_from_address path1;
   MintZRC2 wZil_address _amount;
 
-  (* transfers wZIL balance from this contract to user, that was obtained by using user's ZIL to mint wZIL *)
-  TransferZRC2 wZil_address _sender _amount;
+  (* pre-transfers wZIL balance from this contract straight to pool1 before swap *)
+  TransferZRC2ToPool pool1 path1 _amount;
 
-  SwapZRC2Once pool1 path1 _amount intermediate_amount_out;
-  SwapZRC2Once pool2 path2 intermediate_amount_in final_amount_out;
+  (* swap out ZRC2 tokens straight into pool2 *)
+  SwapZRC2Once pool1 path1 intermediate_amount_out pool2;
+  (* swap out ZRC2 tokens straight back to _sender *)
+  SwapZRC2Once pool2 path2 final_amount_out _sender;
 
   amt_out := zero_amount (* Reassign back to 0 *)
 end
@@ -1648,13 +1678,11 @@ transition SwapExactZILForTokensThrice(
 
   GetAmountOut _amount pool1 path1 deadline_block;
   first_intermediate_amount_out <- amt_out;
-  first_intermediate_amount_in = first_intermediate_amount_out;
-  VerifyValidAmountIn first_intermediate_amount_in;
+  VerifyValidAmountIn first_intermediate_amount_out;
 
-  GetAmountOut first_intermediate_amount_in pool2 path2 deadline_block;
+  GetAmountOut first_intermediate_amount_out pool2 path2 deadline_block;
   second_intermediate_amount_out <- amt_out;
-  second_intermediate_amount_in = second_intermediate_amount_out;
-  VerifyValidAmountIn second_intermediate_amount_in;
+  VerifyValidAmountIn second_intermediate_amount_out;
 
   GetAmountOut second_intermediate_amount_out pool3 path3 deadline_block;
   final_amount_out <- amt_out;
@@ -1666,18 +1694,116 @@ transition SwapExactZILForTokensThrice(
   end;
 
   (* accept ZIL *)
-  (* accept; *)
+  accept;
 
   (* convert ZIL to wZIL *)
-  (* wZil_address = get_from_address path1;
-  MintZRC2 wZil_address _amount; *)
+  wZil_address = get_from_address path1;
+  MintZRC2 wZil_address _amount;
 
-  (* transfers wZIL balance from this contract to user, that was obtained by using user's ZIL to mint wZIL *)
-  (* TransferZRC2 wZil_address _sender _amount; *)
+  (* pre-transfers wZIL balance from this contract straight to pool1 before swap *)
+  TransferZRC2ToPool pool1 path1 _amount;
 
-  SwapZRC2Once pool1 path1 _amount first_intermediate_amount_out;
-  SwapZRC2Once pool2 path2 first_intermediate_amount_in second_intermediate_amount_out;
-  SwapZRC2Once pool3 path3 second_intermediate_amount_in final_amount_out;
+  (* swap out ZRC2 tokens straight into pool2 *)
+  SwapZRC2Once pool1 path1 first_intermediate_amount_out pool2;
+  (* swap out ZRC2 tokens straight into pool3 *)
+  SwapZRC2Once pool2 path2 second_intermediate_amount_out pool3;
+  (* swap out ZRC2 tokens straight back to _sender *)
+  SwapZRC2Once pool3 path3 final_amount_out _sender;
+
+  amt_out := zero_amount (* Reassign back to 0 *)
+end
+
+transition SwapExactZILForTokensQuad(
+  amount_out_min: Uint128,
+  pool1: ByStr20 with contract
+    field reserve0 : Uint128,
+    field reserve1 : Uint128,
+    field amp_bps : Uint128,
+    field v_reserve0 : Uint128,
+    field v_reserve1 : Uint128,
+    field short_ema : Uint256,
+    field long_ema : Uint256
+  end,
+  pool2: ByStr20 with contract
+    field reserve0 : Uint128,
+    field reserve1 : Uint128,
+    field amp_bps : Uint128,
+    field v_reserve0 : Uint128,
+    field v_reserve1 : Uint128,
+    field short_ema : Uint256,
+    field long_ema : Uint256
+  end,
+  pool3: ByStr20 with contract
+    field reserve0 : Uint128,
+    field reserve1 : Uint128,
+    field amp_bps : Uint128,
+    field v_reserve0 : Uint128,
+    field v_reserve1 : Uint128,
+    field short_ema : Uint256,
+    field long_ema : Uint256
+  end,
+  pool4: ByStr20 with contract
+  field reserve0 : Uint128,
+  field reserve1 : Uint128,
+  field amp_bps : Uint128,
+  field v_reserve0 : Uint128,
+  field v_reserve1 : Uint128,
+  field short_ema : Uint256,
+  field long_ema : Uint256
+end,
+  path1: Pair ByStr20 ByStr20,
+  path2: Pair ByStr20 ByStr20,
+  path3: Pair ByStr20 ByStr20,
+  path4: Pair ByStr20 ByStr20,
+  deadline_block: BNum
+)
+  (* Checks if amt_out == 0 *)
+  amount_out <- amt_out;
+  is_valid_amount_out = builtin eq amount_out zero_amount;
+  match is_valid_amount_out with
+  | True => | False =>
+    amt_out := zero_amount
+  end;
+
+  GetAmountOut _amount pool1 path1 deadline_block;
+  first_intermediate_amount_out <- amt_out;
+  VerifyValidAmountIn first_intermediate_amount_out;
+
+  GetAmountOut first_intermediate_amount_out pool2 path2 deadline_block;
+  second_intermediate_amount_out <- amt_out;
+  VerifyValidAmountIn second_intermediate_amount_out;
+
+  GetAmountOut second_intermediate_amount_out pool3 path3 deadline_block;
+  third_intermediate_amount_out <- amt_out;
+  VerifyValidAmountIn third_intermediate_amount_out;
+
+  GetAmountOut third_intermediate_amount_out pool4 path4 deadline_block;
+  final_amount_out <- amt_out;
+  is_valid_final_amount_out = uint128_gt final_amount_out amount_out_min;
+  match is_valid_final_amount_out with 
+  | True => | False => 
+    err = CodeInsufficientOutputAmt;
+    ThrowError err
+  end;
+
+  (* accept ZIL *)
+  accept;
+
+  (* convert ZIL to wZIL *)
+  wZil_address = get_from_address path1;
+  MintZRC2 wZil_address _amount;
+
+  (* pre-transfers wZIL balance from this contract straight to pool1 before swap *)
+  TransferZRC2ToPool pool1 path1 _amount;
+
+  (* swap out ZRC2 tokens straight into pool2 *)
+  SwapZRC2Once pool1 path1 first_intermediate_amount_out pool2;
+  (* swap out ZRC2 tokens straight into pool3 *)
+  SwapZRC2Once pool2 path2 second_intermediate_amount_out pool3;
+  (* swap out ZRC2 tokens straight into pool4 *)
+  SwapZRC2Once pool3 path3 third_intermediate_amount_out pool4;
+  (* swap out ZRC2 tokens straight back to _sender *)
+  SwapZRC2Once pool4 path4 final_amount_out _sender;
 
   amt_out := zero_amount (* Reassign back to 0 *)
 end
@@ -1716,14 +1842,14 @@ transition SwapTokensForExactZILOnce(
     ThrowError err
   end;
 
-  (* swap need to burn wZIL back to ZIL and transfer *)
-  SwapZRC2Once pool path init_amt_in amount_out;
+  (* pre-transfer ZRC2 tokens to pool before swap *)
+  TransferFromZRC2ToPool pool path init_amt_in;
 
-  (* transfer wZIL to this contract *)
+  (* swap out wZIL tokens straight to this contract *)
+  SwapZRC2Once pool path amount_out _this_address;
+
+  (* call Burn on wZIL to convert back to ZIL, callback will handle transfer of ZIL to user *)
   wZil_address = get_to_address path;
-  TransferFromZRC2 wZil_address _sender _this_address amount_out;
-
-  (* call Burn on wZIL to convert back to ZIL, callback will handle transfer of ZIL to user*)
   BurnZRC2 wZil_address amount_out;
 
   amt_in := zero_amount (* Reassign back to 0 *)
@@ -1766,8 +1892,7 @@ transition SwapTokensForExactZILTwice(
   intermediate_amt_in <- amt_in;
   VerifyValidAmountIn intermediate_amt_in;
   
-  intermediate_amt_out = intermediate_amt_in;
-  GetAmountIn intermediate_amt_out pool1 path1 deadline_block;
+  GetAmountIn intermediate_amt_in pool1 path1 deadline_block;
   init_amt_in <- amt_in;
   VerifyValidAmountIn init_amt_in;
 
@@ -1778,15 +1903,16 @@ transition SwapTokensForExactZILTwice(
     ThrowError err
   end;
 
-  (* swap need to burn wZIL back to ZIL and transfer *)
-  SwapZRC2Once pool1 path1 init_amt_in intermediate_amt_out;
-  SwapZRC2Once pool2 path2 intermediate_amt_in amount_out;
+  (* pre-transfer ZRC2 tokens to pool1 before swap *)
+  TransferFromZRC2ToPool pool1 path1 init_amt_in;
 
-  (* transfer wZIL to this contract *)
+  (* swap out ZRC2 tokens straight into pool2 *)
+  SwapZRC2Once pool1 path1 intermediate_amt_in pool2;
+  (* swap out wZIL tokens straight to this contract *)
+  SwapZRC2Once pool2 path2 amount_out _this_address;
+
+  (* call Burn on wZIL to convert back to ZIL, callback will handle transfer of ZIL to user *)
   wZil_address = get_to_address path2;
-  TransferFromZRC2 wZil_address _sender _this_address amount_out;
-
-  (* call Burn on wZIL to convert back to ZIL, callback will handle transfer of ZIL to user*)
   BurnZRC2 wZil_address amount_out;
 
   amt_in := zero_amount (* Reassign back to 0 *)
@@ -1839,13 +1965,11 @@ transition SwapTokensForExactZILThrice(
   second_intermediate_amt_in <- amt_in;
   VerifyValidAmountIn second_intermediate_amt_in;
 
-  second_intermediate_amt_out = second_intermediate_amt_in;
-  GetAmountIn second_intermediate_amt_out pool2 path2 deadline_block;
+  GetAmountIn second_intermediate_amt_in pool2 path2 deadline_block;
   first_intermediate_amt_in <- amt_in;
   VerifyValidAmountIn first_intermediate_amt_in;
   
-  first_intermediate_amt_out = first_intermediate_amt_in;
-  GetAmountIn first_intermediate_amt_out pool1 path1 deadline_block;
+  GetAmountIn first_intermediate_amt_in pool1 path1 deadline_block;
   init_amt_in <- amt_in;
   VerifyValidAmountIn init_amt_in;
 
@@ -1856,16 +1980,18 @@ transition SwapTokensForExactZILThrice(
     ThrowError err
   end;
 
-  (* swap need to burn wZIL back to ZIL and transfer *)
-  SwapZRC2Once pool1 path1 init_amt_in first_intermediate_amt_out;
-  SwapZRC2Once pool2 path2 first_intermediate_amt_in second_intermediate_amt_out;
-  SwapZRC2Once pool3 path3 second_intermediate_amt_in amount_out;
+  (* pre-transfer ZRC2 tokens to pool1 before swap *)
+  TransferFromZRC2ToPool pool1 path1 init_amt_in;
 
-  (* transfer wZIL to this contract *)
+  (* swap out ZRC2 tokens straight into pool2 *)
+  SwapZRC2Once pool1 path1 first_intermediate_amt_in pool2;
+  (* swap out ZRC2 tokens straight into pool3 *)
+  SwapZRC2Once pool2 path2 second_intermediate_amt_in pool3;
+  (* swap out wZIL tokens straight to this contract *)
+  SwapZRC2Once pool3 path3 amount_out _this_address;
+
+  (* call Burn on wZIL to convert back to ZIL, callback will handle transfer of ZIL to user *)
   wZil_address = get_to_address path3;
-  TransferFromZRC2 wZil_address _sender _this_address amount_out;
-
-  (* call Burn on wZIL to convert back to ZIL, callback will handle transfer of ZIL to user*)
   BurnZRC2 wZil_address amount_out;
 
   amt_in := zero_amount (* Reassign back to 0 *)
@@ -1903,14 +2029,14 @@ transition SwapExactTokensForZILOnce(
     ThrowError err
   end;
 
-  (* swap need to burn wZIL back to ZIL and transfer *)
-  SwapZRC2Once pool path amount_in final_amount_out;
+  (* pre-transfer ZRC2 tokens to pool before swap *)
+  TransferFromZRC2ToPool pool path amount_in;
 
-  (* transfer wZIL to this contract *)
-  wZil_address = get_to_address path;
-  TransferFromZRC2 wZil_address _sender _this_address final_amount_out;
+  (* swap out wZIL tokens straight to this contract *)
+  SwapZRC2Once pool path final_amount_out _this_address;
 
   (* call Burn on wZIL to convert back to ZIL, callback will handle transfer of ZIL to user *)
+  wZil_address = get_to_address path;
   BurnZRC2 wZil_address final_amount_out;
 
   amt_out := zero_amount (* Reassign back to 0 *)
@@ -1951,10 +2077,9 @@ transition SwapExactTokensForZILTwice(
 
   GetAmountOut amount_in pool1 path1 deadline_block;
   intermediate_amount_out <- amt_out;
-  intermediate_amount_in = intermediate_amount_out;
-  VerifyValidAmountIn intermediate_amount_in;
+  VerifyValidAmountIn intermediate_amount_out;
 
-  GetAmountOut intermediate_amount_in pool2 path2 deadline_block;
+  GetAmountOut intermediate_amount_out pool2 path2 deadline_block;
   final_amount_out <- amt_out;
   is_valid_final_amount_out = uint128_gt final_amount_out amount_out_min;
   match is_valid_final_amount_out with 
@@ -1963,15 +2088,16 @@ transition SwapExactTokensForZILTwice(
     ThrowError err
   end;
 
-  (* swap need to burn wZIL back to ZIL and transfer *)
-  SwapZRC2Once pool1 path1 amount_in intermediate_amount_out;
-  SwapZRC2Once pool2 path2 intermediate_amount_in final_amount_out;
+  (* pre-transfer ZRC2 tokens to pool1 before swap *)
+  TransferFromZRC2ToPool pool1 path1 amount_in;
 
-  (* transfer wZIL to this contract *)
-  wZil_address = get_to_address path2;
-  TransferFromZRC2 wZil_address _sender _this_address final_amount_out;
+  (* swap out wZIL tokens straight into pool2 *)
+  SwapZRC2Once pool1 path1 intermediate_amount_out pool2;
+  (* swap out wZIL tokens straight to this contract *)
+  SwapZRC2Once pool2 path2 final_amount_out _this_address;
 
   (* call Burn on wZIL to convert back to ZIL, callback will handle transfer of ZIL to user *)
+  wZil_address = get_to_address path2;
   BurnZRC2 wZil_address final_amount_out;
 
   amt_out := zero_amount (* Reassign back to 0 *)
@@ -2022,15 +2148,13 @@ transition SwapExactTokensForZILThrice(
 
   GetAmountOut amount_in pool1 path1 deadline_block;
   first_intermediate_amount_out <- amt_out;
-  first_intermediate_amount_in = first_intermediate_amount_out;
-  VerifyValidAmountIn first_intermediate_amount_in;
+  VerifyValidAmountIn first_intermediate_amount_out;
 
-  GetAmountOut first_intermediate_amount_in pool2 path2 deadline_block;
+  GetAmountOut first_intermediate_amount_out pool2 path2 deadline_block;
   second_intermediate_amount_out <- amt_out;
-  second_intermediate_amount_in = second_intermediate_amount_out;
-  VerifyValidAmountIn second_intermediate_amount_in;
+  VerifyValidAmountIn second_intermediate_amount_out;
 
-  GetAmountOut second_intermediate_amount_in pool3 path3 deadline_block;
+  GetAmountOut second_intermediate_amount_out pool3 path3 deadline_block;
   final_amount_out <- amt_out;
   is_valid_final_amount_out = uint128_gt final_amount_out amount_out_min;
   match is_valid_final_amount_out with 
@@ -2039,16 +2163,18 @@ transition SwapExactTokensForZILThrice(
     ThrowError err
   end;
 
-  (* swap need to burn wZIL back to ZIL and transfer *)
-  SwapZRC2Once pool1 path1 amount_in first_intermediate_amount_out;
-  SwapZRC2Once pool2 path2 first_intermediate_amount_in second_intermediate_amount_out;
-  SwapZRC2Once pool3 path3 second_intermediate_amount_in final_amount_out;
+  (* pre-transfer ZRC2 tokens to pool1 before swap *)
+  TransferFromZRC2ToPool pool1 path1 amount_in;
 
-  (* transfer wZIL to this contract *)
-  wZil_address = get_to_address path3;
-  TransferFromZRC2 wZil_address _sender _this_address final_amount_out;
+  (* swap out wZIL tokens straight into pool2 *)
+  SwapZRC2Once pool1 path1 first_intermediate_amount_out pool2;
+  (* swap out wZIL tokens straight into pool3 *)
+  SwapZRC2Once pool2 path2 second_intermediate_amount_out pool3;
+  (* swap out wZIL tokens straight to this contract *)
+  SwapZRC2Once pool3 path3 final_amount_out _this_address;
 
   (* call Burn on wZIL to convert back to ZIL, callback will handle transfer of ZIL to user *)
+  wZil_address = get_to_address path3;
   BurnZRC2 wZil_address final_amount_out;
 
   amt_out := zero_amount (* Reassign back to 0 *)
@@ -2094,14 +2220,15 @@ transition SwapZILForExactTokensOnce(
   wZil_address = get_from_address path;
   MintZRC2 wZil_address init_amt_in;
 
-  (* transfers wZIL balance from this contract to user, that was obtained by using user's ZIL to mint wZIL *)
-  TransferZRC2 wZil_address _sender init_amt_in;  
-
   (* refund back remaining ZIL not used up in conversion to wZIL *)
   refund = builtin sub _amount init_amt_in;
   Send refund _sender;
 
-  SwapZRC2Once pool path init_amt_in amount_out;
+  (* pre-transfers wZIL balance from this contract straight to pool before swap *)
+  TransferZRC2ToPool pool path init_amt_in;
+
+  (* swap out ZRC2 tokens straight back to _sender *)
+  SwapZRC2Once pool path amount_out _sender;
 
   amt_in := zero_amount (* Reassign back to 0 *)
 end
@@ -2142,8 +2269,7 @@ transition SwapZILForExactTokensTwice(
   intermediate_amt_in <- amt_in;
   VerifyValidAmountIn intermediate_amt_in;
 
-  intermediate_amt_out = intermediate_amt_in;
-  GetAmountIn intermediate_amt_out pool1 path1 deadline_block;
+  GetAmountIn intermediate_amt_in pool1 path1 deadline_block;
   init_amt_in <- amt_in;
   VerifyValidAmountIn init_amt_in;
 
@@ -2161,15 +2287,17 @@ transition SwapZILForExactTokensTwice(
   wZil_address = get_from_address path1;
   MintZRC2 wZil_address init_amt_in;
 
-  (* transfers wZIL balance from this contract to user, that was obtained by using user's ZIL to mint wZIL *)
-  TransferZRC2 wZil_address _sender init_amt_in;  
-
   (* refund back remaining ZIL not used up in conversion to wZIL *)
   refund = builtin sub _amount init_amt_in;
   Send refund _sender;
 
-  SwapZRC2Once pool1 path1 init_amt_in intermediate_amt_out;
-  SwapZRC2Once pool2 path2 intermediate_amt_in amount_out;
+  (* pre-transfers wZIL balance from this contract straight to pool1 before swap *)
+  TransferZRC2ToPool pool1 path1 init_amt_in;
+
+  (* swap out ZRC2 tokens straight into pool2 *)
+  SwapZRC2Once pool1 path1 intermediate_amt_in pool2;
+  (* swap out ZRC2 tokens straight back to _sender *)
+  SwapZRC2Once pool2 path2 amount_out _sender;
 
   amt_in := zero_amount (* Reassign back to 0 *)
 end
@@ -2220,13 +2348,11 @@ transition SwapZILForExactTokensThrice(
   second_intermediate_amt_in <- amt_in;
   VerifyValidAmountIn second_intermediate_amt_in;
   
-  second_intermediate_amt_out = second_intermediate_amt_in;
-  GetAmountIn second_intermediate_amt_out pool2 path2 deadline_block;
+  GetAmountIn second_intermediate_amt_in pool2 path2 deadline_block;
   first_intermediate_amt_in <- amt_in;
   VerifyValidAmountIn first_intermediate_amt_in;
 
-  first_intermediate_amt_out = first_intermediate_amt_in;
-  GetAmountIn first_intermediate_amt_out pool1 path1 deadline_block;
+  GetAmountIn first_intermediate_amt_in pool1 path1 deadline_block;
   init_amt_in <- amt_in;
   VerifyValidAmountIn init_amt_in;
 
@@ -2244,16 +2370,19 @@ transition SwapZILForExactTokensThrice(
   wZil_address = get_from_address path1;
   MintZRC2 wZil_address init_amt_in;
 
-  (* transfers wZIL balance from this contract to user, that was obtained by using user's ZIL to mint wZIL *)
-  TransferZRC2 wZil_address _sender init_amt_in;  
-
   (* refund back remaining ZIL not used up in conversion to wZIL *)
   refund = builtin sub _amount init_amt_in;
   Send refund _sender;
 
-  SwapZRC2Once pool1 path1 init_amt_in first_intermediate_amt_out;
-  SwapZRC2Once pool2 path2 first_intermediate_amt_in second_intermediate_amt_out;
-  SwapZRC2Once pool3 path3 second_intermediate_amt_in amount_out;
+  (* pre-transfers wZIL balance from this contract straight to pool1 before swap *)
+  TransferZRC2ToPool pool1 path1 init_amt_in;
+
+  (* swap out ZRC2 tokens straight into pool2 *)
+  SwapZRC2Once pool1 path1 first_intermediate_amt_in pool2;
+  (* swap out ZRC2 tokens straight into pool3  *)
+  SwapZRC2Once pool2 path2 second_intermediate_amt_in pool3;
+  (* swap out ZRC2 tokens straight back to _sender *)
+  SwapZRC2Once pool3 path3 amount_out _sender;
 
   amt_in := zero_amount (* Reassign back to 0 *)
 end
@@ -2278,12 +2407,12 @@ transition RecipientAcceptTransfer(sender: ByStr20, recipient: ByStr20, amount: 
 end
 
 (* @dev: Handle callback when sending ZRC-2 tokens to the recipient using TransferFrom transition *)
-transition RecipientAcceptTransferFrom (initiator: ByStr20, sender: ByStr20, recipient: ByStr20, amount: Uint128)
+transition RecipientAcceptTransferFrom(initiator: ByStr20, sender: ByStr20, recipient: ByStr20, amount: Uint128)
 (* no-op *)
 end
 
 (* @dev: Handle callback when minting wZIL tokens to the contract *)
-transition RecipientAcceptMint (minter: ByStr20, recipient: ByStr20, amount: Uint128)
+transition RecipientAcceptMint(minter: ByStr20, recipient: ByStr20, amount: Uint128)
 (* no-op *)
 end
 

--- a/src/zilswap-v2/ZilSwapRouter.scilla
+++ b/src/zilswap-v2/ZilSwapRouter.scilla
@@ -304,7 +304,7 @@ end
 
 (* @dev: Validate the pool contract with correct codehash *)
 procedure IsValidPoolContract(pool_address : ByStr20)
-  (* maybe_pool <- & pool_address as ByStr20 with _codehash end;
+  maybe_pool <- & pool_address as ByStr20 with _codehash end;
   match maybe_pool with
   | None =>
   | Some p =>
@@ -317,7 +317,7 @@ procedure IsValidPoolContract(pool_address : ByStr20)
       err = CodeInvalidPool;
       ThrowError err
     end
-  end *)
+  end
 end
 
 procedure AddOnceToPools(tokenA : ByStr20, tokenB : ByStr20, pool : ByStr20)
@@ -385,51 +385,26 @@ procedure VerifyBlock(deadline_block : BNum)
   end
 end
 
-procedure TransferZRC2(token_address: ByStr20, to: ByStr20, amount: Uint128)
-  msg_to_zrc2 = {
-    _tag: "Transfer";
-    _recipient: token_address;
-    _amount: zero_amount;
-    to: to;
-    amount: amount
-  };
-  msg = one_msg msg_to_zrc2;
-  send msg
-end
-
-procedure TransferFromZRC2(token_address: ByStr20, from: ByStr20, to: ByStr20, amount: Uint128)
-  msg_to_zrc2 = {
+(* @dev: Transfer ZRC-2 tokens to pool *)
+procedure TransferZRC2ToPool(pool: ByStr20, token0: ByStr20, token1: ByStr20, amount0: Uint128, amount1: Uint128)
+  msg_to_token0 = {
     _tag: "TransferFrom";
-    _recipient: token_address;
+    _recipient: token0;
     _amount: zero_amount;
-    from: from;
-    to: to;
-    amount: amount
+    from: _sender;
+    to: pool;
+    amount: amount0
   };
-  msg = one_msg msg_to_zrc2;
-  send msg
-end
-
-procedure MintZRC2(token_address: ByStr20, amount: Uint128)
-  msg_to_zrc2 = {
-    _tag: "Mint";
-    _recipient: token_address;
-    _amount: amount
-  };
-  msg = one_msg msg_to_zrc2;
-  send msg
-end
-
-procedure BurnZRC2(token_address: ByStr20, amount: Uint128)
-  msg_to_token = {
-    _tag: "Burn";
-    _recipient: token_address;
+  msg_to_token1 = {
+    _tag: "TransferFrom";
+    _recipient: token1;
     _amount: zero_amount;
-    amount: amount
+    from: _sender;
+    to: pool;
+    amount: amount1
   };
-
-  msg = one_msg msg_to_token;
-  send msg
+  msgs = two_msgs msg_to_token0 msg_to_token1;
+  send msgs
 end
 
 (* @dev: Transfer zil from contract balance to the user *)
@@ -582,79 +557,13 @@ procedure GetAmountIn(
   end
 end
 
-(* @dev: Transfers _sender's ZRC2 tokens into pool *)
-(* @param: path: token_in token_out *)
-procedure TransferFromZRC2ToPool(
-  pool: ByStr20,
-  path: Pair ByStr20 ByStr20,
-  amount_in: Uint128
-)
-  match path with
-  | Pair token_in token_out =>
-    init_token_pair = sort_token path;
-    match init_token_pair with
-    | Pair init_token0 init_token1 =>
-      is_same_order = builtin eq token_in init_token0;
-
-      (* _swap *)
-      match is_same_order with
-      | True =>
-      (* Transfer exact amt of init_token0 to pool *)
-        msg_to_token = {_tag: "TransferFrom"; _recipient: init_token0; _amount: zero_amount;
-                        from: _sender; to: pool; amount: amount_in};
-        msgs = one_msg msg_to_token;
-        send msgs
-      | False =>
-      (* Transfer exact amt of init_token1 to pool *)
-        msg_to_token = {_tag: "TransferFrom"; _recipient: init_token1; _amount: zero_amount;
-                        from: _sender; to: pool; amount: amount_in};
-        msgs = one_msg msg_to_token;
-        send msgs
-      end
-    end
-  end
-end
-
-(* @dev: Transfers this contract's ZRC2 tokens into pool *)
-(* @param: path: token_in token_out *)
-procedure TransferZRC2ToPool(
-  pool: ByStr20,
-  path: Pair ByStr20 ByStr20,
-  amount_in: Uint128
-)
-  match path with
-  | Pair token_in token_out =>
-    init_token_pair = sort_token path;
-    match init_token_pair with
-    | Pair init_token0 init_token1 =>
-      is_same_order = builtin eq token_in init_token0;
-
-      (* _swap *)
-      match is_same_order with
-      | True =>
-      (* Transfer exact amt of init_token0 to pool *)
-        msg_to_token = {_tag: "Transfer"; _recipient: init_token0; _amount: zero_amount;
-                        to: pool; amount: amount_in};
-        msgs = one_msg msg_to_token;
-        send msgs
-      | False =>
-      (* Transfer exact amt of init_token1 to pool *)
-        msg_to_token = {_tag: "Transfer"; _recipient: init_token1; _amount: zero_amount;
-                        to: pool; amount: amount_in};
-        msgs = one_msg msg_to_token;
-        send msgs
-      end
-    end
-  end
-end
-
 (* @dev: Swaps ZRC2 for ZRC2 in one pool *)
 (* @param path: token_in token_out *)
 procedure SwapZRC2Once(
   pool: ByStr20,
-  path: Pair ByStr20 ByStr20, 
-  amount_out: Uint128,
-  to: ByStr20
+  path: Pair ByStr20 ByStr20,
+  amount_in: Uint128, 
+  amount_out: Uint128
 )
   match path with
   | Pair token_in token_out =>
@@ -669,17 +578,63 @@ procedure SwapZRC2Once(
       (* Swap exact amt of init_token0 for init_token1 *)
         amount0_out = zero_amount;
         amount1_out = amount_out;
+        msg_to_token = {_tag: "TransferFrom"; _recipient: init_token0; _amount: zero_amount;
+                      from: _sender; to: pool; amount: amount_in};
         msg_to_pool = {_tag: "Swap"; _recipient: pool; _amount: zero_amount;
-                      amount0_out: amount0_out; amount1_out: amount1_out; to: to};
-        msgs = one_msg msg_to_pool;
+                      amount0_out: amount0_out; amount1_out: amount1_out; to: _sender};
+        msgs = two_msgs msg_to_token msg_to_pool;
         send msgs
       | False =>
       (* Swap exact amt of init_token1 for init_token0 *)
         amount0_out = amount_out;
         amount1_out = zero_amount;
+        msg_to_token = {_tag: "TransferFrom"; _recipient: init_token1; _amount: zero_amount;
+                        from: _sender; to: pool; amount: amount_in};
         msg_to_pool = {_tag: "Swap"; _recipient: pool; _amount: zero_amount;
-                      amount0_out: amount0_out; amount1_out: amount1_out; to: to};
-        msgs = one_msg msg_to_pool;
+                      amount0_out: amount0_out; amount1_out: amount1_out; to: _sender};
+        msgs = two_msgs msg_to_token msg_to_pool;
+        send msgs
+      end
+    end
+  end
+end
+
+(* @dev: Swaps wZIL for ZRC2 in one pool, with the wZIL coming from this contract to save steps of transferring back to _sender *)
+(* @param path: token_in token_out *)
+procedure SwapWZILZRC2Once(
+  pool: ByStr20,
+  path: Pair ByStr20 ByStr20,
+  amount_in: Uint128, 
+  amount_out: Uint128
+)
+  match path with
+  | Pair token_in token_out =>
+    init_token_pair = sort_token path;
+    match init_token_pair with
+    | Pair init_token0 init_token1 =>
+      is_same_order = builtin eq token_in init_token0;
+
+      (* _swap *)
+      match is_same_order with
+      | True =>
+      (* Swap exact amt of init_token0 for init_token1 *)
+        amount0_out = zero_amount;
+        amount1_out = amount_out;
+        msg_to_token = {_tag: "Transfer"; _recipient: init_token0; _amount: zero_amount;
+                      to: pool; amount: amount_in};
+        msg_to_pool = {_tag: "Swap"; _recipient: pool; _amount: zero_amount;
+                      amount0_out: amount0_out; amount1_out: amount1_out; to: _sender};
+        msgs = two_msgs msg_to_token msg_to_pool;
+        send msgs
+      | False =>
+      (* Swap exact amt of init_token1 for init_token0 *)
+        amount0_out = amount_out;
+        amount1_out = zero_amount;
+        msg_to_token = {_tag: "Transfer"; _recipient: init_token1; _amount: zero_amount;
+                      to: pool; amount: amount_in};
+        msg_to_pool = {_tag: "Swap"; _recipient: pool; _amount: zero_amount;
+                      amount0_out: amount0_out; amount1_out: amount1_out; to: _sender};
+        msgs = two_msgs msg_to_token msg_to_pool;
         send msgs
       end
     end
@@ -713,6 +668,53 @@ procedure IsPendingGovernor(address: ByStr20)
     err = CodeNotPendingGovernor;
     ThrowError err
   end
+end
+
+procedure TransferZRC2(token_address: ByStr20, to: ByStr20, amount: Uint128)
+  msg_to_zrc2 = {
+    _tag: "Transfer";
+    _recipient: token_address;
+    _amount: zero_amount;
+    to: to;
+    amount: amount
+  };
+  msg = one_msg msg_to_zrc2;
+  send msg
+end
+
+procedure TransferFromZRC2(token_address: ByStr20, from: ByStr20, to: ByStr20, amount: Uint128)
+  msg_to_zrc2 = {
+    _tag: "TransferFrom";
+    _recipient: token_address;
+    _amount: zero_amount;
+    from: from;
+    to: to;
+    amount: amount
+  };
+  msg = one_msg msg_to_zrc2;
+  send msg
+end
+
+procedure MintZRC2(token_address: ByStr20, amount: Uint128)
+  msg_to_zrc2 = {
+    _tag: "Mint";
+    _recipient: token_address;
+    _amount: amount
+  };
+  msg = one_msg msg_to_zrc2;
+  send msg
+end
+
+procedure BurnZRC2(token_address: ByStr20, amount: Uint128)
+  msg_to_token = {
+    _tag: "Burn";
+    _recipient: token_address;
+    _amount: zero_amount;
+    amount: amount
+  };
+
+  msg = one_msg msg_to_token;
+  send msg
 end
 
 (***************************************)
@@ -850,8 +852,7 @@ transition AddLiquidity(
     (* Transfer pairing of tokenA and tokenB to pool *)
     amountA = amountA_desired;
     amountB = amountB_desired;
-    TransferFromZRC2 tokenA _sender pool amountA;
-    TransferFromZRC2 tokenB _sender pool amountB
+    TransferZRC2ToPool pool tokenA tokenB amountA amountB
   | False =>
     (* pool with existing liquidity *)
     (* check how much tokenB is required to fulfil amountA_desired pairing *)
@@ -871,8 +872,7 @@ transition AddLiquidity(
       (* Transfer pairing of tokenA and tokenB to pool *)
       amountA = amountA_desired;
       amountB = amountB_optimal;
-      TransferFromZRC2 tokenA _sender pool amountA;
-      TransferFromZRC2 tokenB _sender pool amountB
+      TransferZRC2ToPool pool tokenA tokenB amountA amountB
     | False =>
       (* insufficient tokenB is provided *)
       (* check how much tokenA is required to fulfil amountB_desired pairing *)
@@ -888,8 +888,7 @@ transition AddLiquidity(
       (* Transfer pairing of tokenA and tokenB to pool *)
       amountA = amountA_optimal;
       amountB = amountB_desired;
-      TransferFromZRC2 tokenA _sender pool amountA;
-      TransferFromZRC2 tokenB _sender pool amountB
+      TransferZRC2ToPool pool tokenA tokenB amountA amountB
     end;
 
     amp <- & pool.amp_bps;
@@ -970,8 +969,7 @@ transition AddLiquidityZIL(
     TransferZRC2 wZIL _sender amount_wZIL;
 
     (* Transfer pairing of wZIL and token to pool *)
-    TransferFromZRC2 token _sender pool amount_token;
-    TransferFromZRC2 wZIL _sender pool amount_wZIL
+    TransferZRC2ToPool pool token wZIL amount_token amount_wZIL
   | False =>
     (* pool with existing liquidity *)
     (* check how much wZIL is required to fulfil amount_token_desired pairing *)
@@ -1002,8 +1000,7 @@ transition AddLiquidityZIL(
       Send refund _sender;
 
       (* Transfer pairing of wZIL and token to pool *)
-      TransferFromZRC2 token _sender pool amount_token;
-      TransferFromZRC2 wZIL _sender pool amount_wZIL
+      TransferZRC2ToPool pool token wZIL amount_token amount_wZIL
     | False =>
       (* insufficient wZIL provided *)
       (* check how many tokens are required to fulfil wZIL pairing, based on insufficient wZIL provided *)
@@ -1026,8 +1023,7 @@ transition AddLiquidityZIL(
       TransferZRC2 wZIL _sender amount_wZIL;
       
       (* Transfer pairing of wZIL and token to pool *)
-      TransferFromZRC2 token _sender pool amount_token;
-      TransferFromZRC2 wZIL _sender pool amount_wZIL
+      TransferZRC2ToPool pool token wZIL amount_token amount_wZIL
     end;
 
     amp <- & pool.amp_bps;
@@ -1198,11 +1194,7 @@ transition SwapExactTokensForTokensOnce(
     ThrowError err
   end;
 
-  (* pre-transfer ZRC2 tokens to pool before swap *)
-  TransferFromZRC2ToPool pool path amount_in;
-  
-  (* swap out ZRC2 tokens straight back to _sender *)
-  SwapZRC2Once pool path final_amount_out _sender;
+  SwapZRC2Once pool path amount_in final_amount_out;
   amt_out := zero_amount (* Reassign back to 0 *)
 end
 
@@ -1243,9 +1235,10 @@ transition SwapExactTokensForTokensTwice(
 
   GetAmountOut amount_in pool1 path1 deadline_block;
   intermediate_amount_out <- amt_out;
-  VerifyValidAmountIn intermediate_amount_out;
+  intermediate_amount_in = intermediate_amount_out;
+  VerifyValidAmountIn intermediate_amount_in;
 
-  GetAmountOut intermediate_amount_out pool2 path2 deadline_block;
+  GetAmountOut intermediate_amount_in pool2 path2 deadline_block;
   final_amount_out <- amt_out;
   is_valid_final_amount_out = uint128_gt final_amount_out amount_out_min;
   match is_valid_final_amount_out with 
@@ -1254,13 +1247,8 @@ transition SwapExactTokensForTokensTwice(
     ThrowError err
   end;
   
-  (* pre-transfer ZRC2 tokens to pool1 before swap *)
-  TransferFromZRC2ToPool pool1 path1 amount_in;
-
-  (* swap out ZRC2 tokens straight into pool2 *)
-  SwapZRC2Once pool1 path1 intermediate_amount_out pool2;
-  (* swap out ZRC2 tokens straight back to _sender *)
-  SwapZRC2Once pool2 path2 final_amount_out _sender;
+  SwapZRC2Once pool1 path1 amount_in intermediate_amount_out;
+  SwapZRC2Once pool2 path2 intermediate_amount_in final_amount_out;
 
   amt_out := zero_amount (* Reassign back to 0 *)
 end
@@ -1314,13 +1302,15 @@ transition SwapExactTokensForTokensThrice(
 
   GetAmountOut amount_in pool1 path1 deadline_block;
   first_intermediate_amount_out <- amt_out;
-  VerifyValidAmountIn first_intermediate_amount_out;
+  first_intermediate_amount_in = first_intermediate_amount_out;
+  VerifyValidAmountIn first_intermediate_amount_in;
 
-  GetAmountOut first_intermediate_amount_out pool2 path2 deadline_block;
+  GetAmountOut first_intermediate_amount_in pool2 path2 deadline_block;
   second_intermediate_amount_out <- amt_out;
-  VerifyValidAmountIn second_intermediate_amount_out;
+  second_intermediate_amount_in = second_intermediate_amount_out;
+  VerifyValidAmountIn second_intermediate_amount_in;
 
-  GetAmountOut second_intermediate_amount_out pool3 path3 deadline_block;
+  GetAmountOut second_intermediate_amount_in pool3 path3 deadline_block;
   final_amount_out <- amt_out;
   is_valid_final_amount_out = uint128_gt final_amount_out amount_out_min;
   match is_valid_final_amount_out with 
@@ -1329,15 +1319,9 @@ transition SwapExactTokensForTokensThrice(
     ThrowError err
   end;
 
-  (* pre-transfer ZRC2 tokens to pool1 before swap *)
-  TransferFromZRC2ToPool pool1 path1 amount_in;
-
-  (* swap out ZRC2 tokens straight into pool2 *)
-  SwapZRC2Once pool1 path1 first_intermediate_amount_out pool2;
-  (* swap out ZRC2 tokens straight into pool3 *)
-  SwapZRC2Once pool2 path2 second_intermediate_amount_out pool3;
-  (* swap out ZRC2 tokens straight back to _sender *)
-  SwapZRC2Once pool3 path3 final_amount_out _sender;
+  SwapZRC2Once pool1 path1 amount_in first_intermediate_amount_out;
+  SwapZRC2Once pool2 path2 first_intermediate_amount_in second_intermediate_amount_out;
+  SwapZRC2Once pool3 path3 second_intermediate_amount_in final_amount_out;
 
   amt_out := zero_amount (* Reassign back to 0 *)
 end
@@ -1378,11 +1362,7 @@ transition SwapTokensForExactTokensOnce(
     ThrowError err
   end;
 
-  (* pre-transfer ZRC2 tokens to pool before swap *)
-  TransferFromZRC2ToPool pool path init_amt_in;
-
-  (* swap out ZRC2 tokens straight back to _sender *)
-  SwapZRC2Once pool path amount_out _sender;
+  SwapZRC2Once pool path init_amt_in amount_out;
   amt_in := zero_amount (* Reassign back to 0 *)
 end
 
@@ -1423,7 +1403,8 @@ transition SwapTokensForExactTokensTwice(
   intermediate_amt_in <- amt_in;
   VerifyValidAmountIn intermediate_amt_in;
 
-  GetAmountIn intermediate_amt_in pool1 path1 deadline_block;
+  intermediate_amt_out = intermediate_amt_in;
+  GetAmountIn intermediate_amt_out pool1 path1 deadline_block;
   init_amt_in <- amt_in;
   VerifyValidAmountIn init_amt_in;
 
@@ -1434,13 +1415,8 @@ transition SwapTokensForExactTokensTwice(
     ThrowError err
   end;
 
-  (* pre-transfer ZRC2 tokens to pool1 before swap *)
-  TransferFromZRC2ToPool pool1 path1 init_amt_in;
-
-  (* swap out ZRC2 tokens straight into pool2 *)
-  SwapZRC2Once pool1 path1 intermediate_amt_in pool2;
-  (* swap out ZRC2 tokens straight back to _sender *)
-  SwapZRC2Once pool2 path2 amount_out _sender;
+  SwapZRC2Once pool1 path1 init_amt_in intermediate_amt_out;
+  SwapZRC2Once pool2 path2 intermediate_amt_in amount_out;
 
   amt_in := zero_amount (* Reassign back to 0 *)
 end
@@ -1496,11 +1472,13 @@ transition SwapTokensForExactTokensThrice(
   second_intermediate_amt_in <- amt_in;
   VerifyValidAmountIn second_intermediate_amt_in;
 
-  GetAmountIn second_intermediate_amt_in pool2 path2 deadline_block;
+  second_intermediate_amt_out = second_intermediate_amt_in;
+  GetAmountIn second_intermediate_amt_out pool2 path2 deadline_block;
   first_intermediate_amt_in <- amt_in;
   VerifyValidAmountIn first_intermediate_amt_in;
 
-  GetAmountIn first_intermediate_amt_in pool1 path1 deadline_block;
+  first_intermediate_amt_out = first_intermediate_amt_in;
+  GetAmountIn first_intermediate_amt_out pool1 path1 deadline_block;
   init_amt_in <- amt_in;
   VerifyValidAmountIn init_amt_in;
 
@@ -1511,15 +1489,9 @@ transition SwapTokensForExactTokensThrice(
     ThrowError err
   end;
 
-  (* pre-transfer ZRC2 tokens to pool1 before swap *)
-  TransferFromZRC2ToPool pool1 path1 init_amt_in;
-
-  (* swap out ZRC2 tokens straight into pool2 *)
-  SwapZRC2Once pool1 path1 first_intermediate_amt_in pool2;
-  (* swap out ZRC2 tokens straight into pool3 *)
-  SwapZRC2Once pool2 path2 second_intermediate_amt_in pool3;
-  (* swap out ZRC2 tokens straight back to _sender *)
-  SwapZRC2Once pool3 path3 amount_out _sender;
+  SwapZRC2Once pool1 path1 init_amt_in first_intermediate_amt_out;
+  SwapZRC2Once pool2 path2 first_intermediate_amt_in second_intermediate_amt_out;
+  SwapZRC2Once pool3 path3 second_intermediate_amt_in amount_out;
 
   amt_in := zero_amount (* Reassign back to 0 *)
 end
@@ -1562,11 +1534,10 @@ transition SwapExactZILForTokensOnce(
   wZil_address = get_from_address path;
   MintZRC2 wZil_address _amount;
 
-  (* pre-transfers wZIL balance from this contract straight to pool before swap *)
-  TransferZRC2ToPool pool path _amount;
+  (* transfers wZIL balance from this contract to user, that was obtained by using user's ZIL to mint wZIL *)
+  TransferZRC2 wZil_address _sender _amount;
 
-  (* swap out ZRC2 tokens straight back to _sender *)
-  SwapZRC2Once pool path final_amount_out _sender;
+  SwapZRC2Once pool path _amount final_amount_out;
 
   amt_out := zero_amount (* Reassign back to 0 *)
 end
@@ -1605,9 +1576,10 @@ transition SwapExactZILForTokensTwice(
 
   GetAmountOut _amount pool1 path1 deadline_block;
   intermediate_amount_out <- amt_out;
-  VerifyValidAmountIn intermediate_amount_out;
+  intermediate_amount_in = intermediate_amount_out;
+  VerifyValidAmountIn intermediate_amount_in;
 
-  GetAmountOut intermediate_amount_out pool2 path2 deadline_block;
+  GetAmountOut intermediate_amount_in pool2 path2 deadline_block;
   final_amount_out <- amt_out;
   is_valid_final_amount_out = uint128_gt final_amount_out amount_out_min;
   match is_valid_final_amount_out with 
@@ -1623,13 +1595,11 @@ transition SwapExactZILForTokensTwice(
   wZil_address = get_from_address path1;
   MintZRC2 wZil_address _amount;
 
-  (* pre-transfers wZIL balance from this contract straight to pool1 before swap *)
-  TransferZRC2ToPool pool1 path1 _amount;
+  (* transfers wZIL balance from this contract to user, that was obtained by using user's ZIL to mint wZIL *)
+  TransferZRC2 wZil_address _sender _amount;
 
-  (* swap out ZRC2 tokens straight into pool2 *)
-  SwapZRC2Once pool1 path1 intermediate_amount_out pool2;
-  (* swap out ZRC2 tokens straight back to _sender *)
-  SwapZRC2Once pool2 path2 final_amount_out _sender;
+  SwapZRC2Once pool1 path1 _amount intermediate_amount_out;
+  SwapZRC2Once pool2 path2 intermediate_amount_in final_amount_out;
 
   amt_out := zero_amount (* Reassign back to 0 *)
 end
@@ -1678,11 +1648,13 @@ transition SwapExactZILForTokensThrice(
 
   GetAmountOut _amount pool1 path1 deadline_block;
   first_intermediate_amount_out <- amt_out;
-  VerifyValidAmountIn first_intermediate_amount_out;
+  first_intermediate_amount_in = first_intermediate_amount_out;
+  VerifyValidAmountIn first_intermediate_amount_in;
 
-  GetAmountOut first_intermediate_amount_out pool2 path2 deadline_block;
+  GetAmountOut first_intermediate_amount_in pool2 path2 deadline_block;
   second_intermediate_amount_out <- amt_out;
-  VerifyValidAmountIn second_intermediate_amount_out;
+  second_intermediate_amount_in = second_intermediate_amount_out;
+  VerifyValidAmountIn second_intermediate_amount_in;
 
   GetAmountOut second_intermediate_amount_out pool3 path3 deadline_block;
   final_amount_out <- amt_out;
@@ -1694,116 +1666,18 @@ transition SwapExactZILForTokensThrice(
   end;
 
   (* accept ZIL *)
-  accept;
+  (* accept; *)
 
   (* convert ZIL to wZIL *)
-  wZil_address = get_from_address path1;
-  MintZRC2 wZil_address _amount;
+  (* wZil_address = get_from_address path1;
+  MintZRC2 wZil_address _amount; *)
 
-  (* pre-transfers wZIL balance from this contract straight to pool1 before swap *)
-  TransferZRC2ToPool pool1 path1 _amount;
+  (* transfers wZIL balance from this contract to user, that was obtained by using user's ZIL to mint wZIL *)
+  (* TransferZRC2 wZil_address _sender _amount; *)
 
-  (* swap out ZRC2 tokens straight into pool2 *)
-  SwapZRC2Once pool1 path1 first_intermediate_amount_out pool2;
-  (* swap out ZRC2 tokens straight into pool3 *)
-  SwapZRC2Once pool2 path2 second_intermediate_amount_out pool3;
-  (* swap out ZRC2 tokens straight back to _sender *)
-  SwapZRC2Once pool3 path3 final_amount_out _sender;
-
-  amt_out := zero_amount (* Reassign back to 0 *)
-end
-
-transition SwapExactZILForTokensQuad(
-  amount_out_min: Uint128,
-  pool1: ByStr20 with contract
-    field reserve0 : Uint128,
-    field reserve1 : Uint128,
-    field amp_bps : Uint128,
-    field v_reserve0 : Uint128,
-    field v_reserve1 : Uint128,
-    field short_ema : Uint256,
-    field long_ema : Uint256
-  end,
-  pool2: ByStr20 with contract
-    field reserve0 : Uint128,
-    field reserve1 : Uint128,
-    field amp_bps : Uint128,
-    field v_reserve0 : Uint128,
-    field v_reserve1 : Uint128,
-    field short_ema : Uint256,
-    field long_ema : Uint256
-  end,
-  pool3: ByStr20 with contract
-    field reserve0 : Uint128,
-    field reserve1 : Uint128,
-    field amp_bps : Uint128,
-    field v_reserve0 : Uint128,
-    field v_reserve1 : Uint128,
-    field short_ema : Uint256,
-    field long_ema : Uint256
-  end,
-  pool4: ByStr20 with contract
-  field reserve0 : Uint128,
-  field reserve1 : Uint128,
-  field amp_bps : Uint128,
-  field v_reserve0 : Uint128,
-  field v_reserve1 : Uint128,
-  field short_ema : Uint256,
-  field long_ema : Uint256
-end,
-  path1: Pair ByStr20 ByStr20,
-  path2: Pair ByStr20 ByStr20,
-  path3: Pair ByStr20 ByStr20,
-  path4: Pair ByStr20 ByStr20,
-  deadline_block: BNum
-)
-  (* Checks if amt_out == 0 *)
-  amount_out <- amt_out;
-  is_valid_amount_out = builtin eq amount_out zero_amount;
-  match is_valid_amount_out with
-  | True => | False =>
-    amt_out := zero_amount
-  end;
-
-  GetAmountOut _amount pool1 path1 deadline_block;
-  first_intermediate_amount_out <- amt_out;
-  VerifyValidAmountIn first_intermediate_amount_out;
-
-  GetAmountOut first_intermediate_amount_out pool2 path2 deadline_block;
-  second_intermediate_amount_out <- amt_out;
-  VerifyValidAmountIn second_intermediate_amount_out;
-
-  GetAmountOut second_intermediate_amount_out pool3 path3 deadline_block;
-  third_intermediate_amount_out <- amt_out;
-  VerifyValidAmountIn third_intermediate_amount_out;
-
-  GetAmountOut third_intermediate_amount_out pool4 path4 deadline_block;
-  final_amount_out <- amt_out;
-  is_valid_final_amount_out = uint128_gt final_amount_out amount_out_min;
-  match is_valid_final_amount_out with 
-  | True => | False => 
-    err = CodeInsufficientOutputAmt;
-    ThrowError err
-  end;
-
-  (* accept ZIL *)
-  accept;
-
-  (* convert ZIL to wZIL *)
-  wZil_address = get_from_address path1;
-  MintZRC2 wZil_address _amount;
-
-  (* pre-transfers wZIL balance from this contract straight to pool1 before swap *)
-  TransferZRC2ToPool pool1 path1 _amount;
-
-  (* swap out ZRC2 tokens straight into pool2 *)
-  SwapZRC2Once pool1 path1 first_intermediate_amount_out pool2;
-  (* swap out ZRC2 tokens straight into pool3 *)
-  SwapZRC2Once pool2 path2 second_intermediate_amount_out pool3;
-  (* swap out ZRC2 tokens straight into pool4 *)
-  SwapZRC2Once pool3 path3 third_intermediate_amount_out pool4;
-  (* swap out ZRC2 tokens straight back to _sender *)
-  SwapZRC2Once pool4 path4 final_amount_out _sender;
+  SwapZRC2Once pool1 path1 _amount first_intermediate_amount_out;
+  SwapZRC2Once pool2 path2 first_intermediate_amount_in second_intermediate_amount_out;
+  SwapZRC2Once pool3 path3 second_intermediate_amount_in final_amount_out;
 
   amt_out := zero_amount (* Reassign back to 0 *)
 end
@@ -1842,14 +1716,14 @@ transition SwapTokensForExactZILOnce(
     ThrowError err
   end;
 
-  (* pre-transfer ZRC2 tokens to pool before swap *)
-  TransferFromZRC2ToPool pool path init_amt_in;
+  (* swap need to burn wZIL back to ZIL and transfer *)
+  SwapZRC2Once pool path init_amt_in amount_out;
 
-  (* swap out wZIL tokens straight to this contract *)
-  SwapZRC2Once pool path amount_out _this_address;
-
-  (* call Burn on wZIL to convert back to ZIL, callback will handle transfer of ZIL to user *)
+  (* transfer wZIL to this contract *)
   wZil_address = get_to_address path;
+  TransferFromZRC2 wZil_address _sender _this_address amount_out;
+
+  (* call Burn on wZIL to convert back to ZIL, callback will handle transfer of ZIL to user*)
   BurnZRC2 wZil_address amount_out;
 
   amt_in := zero_amount (* Reassign back to 0 *)
@@ -1892,7 +1766,8 @@ transition SwapTokensForExactZILTwice(
   intermediate_amt_in <- amt_in;
   VerifyValidAmountIn intermediate_amt_in;
   
-  GetAmountIn intermediate_amt_in pool1 path1 deadline_block;
+  intermediate_amt_out = intermediate_amt_in;
+  GetAmountIn intermediate_amt_out pool1 path1 deadline_block;
   init_amt_in <- amt_in;
   VerifyValidAmountIn init_amt_in;
 
@@ -1903,16 +1778,15 @@ transition SwapTokensForExactZILTwice(
     ThrowError err
   end;
 
-  (* pre-transfer ZRC2 tokens to pool1 before swap *)
-  TransferFromZRC2ToPool pool1 path1 init_amt_in;
+  (* swap need to burn wZIL back to ZIL and transfer *)
+  SwapZRC2Once pool1 path1 init_amt_in intermediate_amt_out;
+  SwapZRC2Once pool2 path2 intermediate_amt_in amount_out;
 
-  (* swap out ZRC2 tokens straight into pool2 *)
-  SwapZRC2Once pool1 path1 intermediate_amt_in pool2;
-  (* swap out wZIL tokens straight to this contract *)
-  SwapZRC2Once pool2 path2 amount_out _this_address;
-
-  (* call Burn on wZIL to convert back to ZIL, callback will handle transfer of ZIL to user *)
+  (* transfer wZIL to this contract *)
   wZil_address = get_to_address path2;
+  TransferFromZRC2 wZil_address _sender _this_address amount_out;
+
+  (* call Burn on wZIL to convert back to ZIL, callback will handle transfer of ZIL to user*)
   BurnZRC2 wZil_address amount_out;
 
   amt_in := zero_amount (* Reassign back to 0 *)
@@ -1965,11 +1839,13 @@ transition SwapTokensForExactZILThrice(
   second_intermediate_amt_in <- amt_in;
   VerifyValidAmountIn second_intermediate_amt_in;
 
-  GetAmountIn second_intermediate_amt_in pool2 path2 deadline_block;
+  second_intermediate_amt_out = second_intermediate_amt_in;
+  GetAmountIn second_intermediate_amt_out pool2 path2 deadline_block;
   first_intermediate_amt_in <- amt_in;
   VerifyValidAmountIn first_intermediate_amt_in;
   
-  GetAmountIn first_intermediate_amt_in pool1 path1 deadline_block;
+  first_intermediate_amt_out = first_intermediate_amt_in;
+  GetAmountIn first_intermediate_amt_out pool1 path1 deadline_block;
   init_amt_in <- amt_in;
   VerifyValidAmountIn init_amt_in;
 
@@ -1980,18 +1856,16 @@ transition SwapTokensForExactZILThrice(
     ThrowError err
   end;
 
-  (* pre-transfer ZRC2 tokens to pool1 before swap *)
-  TransferFromZRC2ToPool pool1 path1 init_amt_in;
+  (* swap need to burn wZIL back to ZIL and transfer *)
+  SwapZRC2Once pool1 path1 init_amt_in first_intermediate_amt_out;
+  SwapZRC2Once pool2 path2 first_intermediate_amt_in second_intermediate_amt_out;
+  SwapZRC2Once pool3 path3 second_intermediate_amt_in amount_out;
 
-  (* swap out ZRC2 tokens straight into pool2 *)
-  SwapZRC2Once pool1 path1 first_intermediate_amt_in pool2;
-  (* swap out ZRC2 tokens straight into pool3 *)
-  SwapZRC2Once pool2 path2 second_intermediate_amt_in pool3;
-  (* swap out wZIL tokens straight to this contract *)
-  SwapZRC2Once pool3 path3 amount_out _this_address;
-
-  (* call Burn on wZIL to convert back to ZIL, callback will handle transfer of ZIL to user *)
+  (* transfer wZIL to this contract *)
   wZil_address = get_to_address path3;
+  TransferFromZRC2 wZil_address _sender _this_address amount_out;
+
+  (* call Burn on wZIL to convert back to ZIL, callback will handle transfer of ZIL to user*)
   BurnZRC2 wZil_address amount_out;
 
   amt_in := zero_amount (* Reassign back to 0 *)
@@ -2029,14 +1903,14 @@ transition SwapExactTokensForZILOnce(
     ThrowError err
   end;
 
-  (* pre-transfer ZRC2 tokens to pool before swap *)
-  TransferFromZRC2ToPool pool path amount_in;
+  (* swap need to burn wZIL back to ZIL and transfer *)
+  SwapZRC2Once pool path amount_in final_amount_out;
 
-  (* swap out wZIL tokens straight to this contract *)
-  SwapZRC2Once pool path final_amount_out _this_address;
+  (* transfer wZIL to this contract *)
+  wZil_address = get_to_address path;
+  TransferFromZRC2 wZil_address _sender _this_address final_amount_out;
 
   (* call Burn on wZIL to convert back to ZIL, callback will handle transfer of ZIL to user *)
-  wZil_address = get_to_address path;
   BurnZRC2 wZil_address final_amount_out;
 
   amt_out := zero_amount (* Reassign back to 0 *)
@@ -2077,9 +1951,10 @@ transition SwapExactTokensForZILTwice(
 
   GetAmountOut amount_in pool1 path1 deadline_block;
   intermediate_amount_out <- amt_out;
-  VerifyValidAmountIn intermediate_amount_out;
+  intermediate_amount_in = intermediate_amount_out;
+  VerifyValidAmountIn intermediate_amount_in;
 
-  GetAmountOut intermediate_amount_out pool2 path2 deadline_block;
+  GetAmountOut intermediate_amount_in pool2 path2 deadline_block;
   final_amount_out <- amt_out;
   is_valid_final_amount_out = uint128_gt final_amount_out amount_out_min;
   match is_valid_final_amount_out with 
@@ -2088,16 +1963,15 @@ transition SwapExactTokensForZILTwice(
     ThrowError err
   end;
 
-  (* pre-transfer ZRC2 tokens to pool1 before swap *)
-  TransferFromZRC2ToPool pool1 path1 amount_in;
+  (* swap need to burn wZIL back to ZIL and transfer *)
+  SwapZRC2Once pool1 path1 amount_in intermediate_amount_out;
+  SwapZRC2Once pool2 path2 intermediate_amount_in final_amount_out;
 
-  (* swap out wZIL tokens straight into pool2 *)
-  SwapZRC2Once pool1 path1 intermediate_amount_out pool2;
-  (* swap out wZIL tokens straight to this contract *)
-  SwapZRC2Once pool2 path2 final_amount_out _this_address;
+  (* transfer wZIL to this contract *)
+  wZil_address = get_to_address path2;
+  TransferFromZRC2 wZil_address _sender _this_address final_amount_out;
 
   (* call Burn on wZIL to convert back to ZIL, callback will handle transfer of ZIL to user *)
-  wZil_address = get_to_address path2;
   BurnZRC2 wZil_address final_amount_out;
 
   amt_out := zero_amount (* Reassign back to 0 *)
@@ -2148,13 +2022,15 @@ transition SwapExactTokensForZILThrice(
 
   GetAmountOut amount_in pool1 path1 deadline_block;
   first_intermediate_amount_out <- amt_out;
-  VerifyValidAmountIn first_intermediate_amount_out;
+  first_intermediate_amount_in = first_intermediate_amount_out;
+  VerifyValidAmountIn first_intermediate_amount_in;
 
-  GetAmountOut first_intermediate_amount_out pool2 path2 deadline_block;
+  GetAmountOut first_intermediate_amount_in pool2 path2 deadline_block;
   second_intermediate_amount_out <- amt_out;
-  VerifyValidAmountIn second_intermediate_amount_out;
+  second_intermediate_amount_in = second_intermediate_amount_out;
+  VerifyValidAmountIn second_intermediate_amount_in;
 
-  GetAmountOut second_intermediate_amount_out pool3 path3 deadline_block;
+  GetAmountOut second_intermediate_amount_in pool3 path3 deadline_block;
   final_amount_out <- amt_out;
   is_valid_final_amount_out = uint128_gt final_amount_out amount_out_min;
   match is_valid_final_amount_out with 
@@ -2163,18 +2039,16 @@ transition SwapExactTokensForZILThrice(
     ThrowError err
   end;
 
-  (* pre-transfer ZRC2 tokens to pool1 before swap *)
-  TransferFromZRC2ToPool pool1 path1 amount_in;
+  (* swap need to burn wZIL back to ZIL and transfer *)
+  SwapZRC2Once pool1 path1 amount_in first_intermediate_amount_out;
+  SwapZRC2Once pool2 path2 first_intermediate_amount_in second_intermediate_amount_out;
+  SwapZRC2Once pool3 path3 second_intermediate_amount_in final_amount_out;
 
-  (* swap out wZIL tokens straight into pool2 *)
-  SwapZRC2Once pool1 path1 first_intermediate_amount_out pool2;
-  (* swap out wZIL tokens straight into pool3 *)
-  SwapZRC2Once pool2 path2 second_intermediate_amount_out pool3;
-  (* swap out wZIL tokens straight to this contract *)
-  SwapZRC2Once pool3 path3 final_amount_out _this_address;
+  (* transfer wZIL to this contract *)
+  wZil_address = get_to_address path3;
+  TransferFromZRC2 wZil_address _sender _this_address final_amount_out;
 
   (* call Burn on wZIL to convert back to ZIL, callback will handle transfer of ZIL to user *)
-  wZil_address = get_to_address path3;
   BurnZRC2 wZil_address final_amount_out;
 
   amt_out := zero_amount (* Reassign back to 0 *)
@@ -2220,15 +2094,14 @@ transition SwapZILForExactTokensOnce(
   wZil_address = get_from_address path;
   MintZRC2 wZil_address init_amt_in;
 
+  (* transfers wZIL balance from this contract to user, that was obtained by using user's ZIL to mint wZIL *)
+  TransferZRC2 wZil_address _sender init_amt_in;  
+
   (* refund back remaining ZIL not used up in conversion to wZIL *)
   refund = builtin sub _amount init_amt_in;
   Send refund _sender;
 
-  (* pre-transfers wZIL balance from this contract straight to pool before swap *)
-  TransferZRC2ToPool pool path init_amt_in;
-
-  (* swap out ZRC2 tokens straight back to _sender *)
-  SwapZRC2Once pool path amount_out _sender;
+  SwapZRC2Once pool path init_amt_in amount_out;
 
   amt_in := zero_amount (* Reassign back to 0 *)
 end
@@ -2269,7 +2142,8 @@ transition SwapZILForExactTokensTwice(
   intermediate_amt_in <- amt_in;
   VerifyValidAmountIn intermediate_amt_in;
 
-  GetAmountIn intermediate_amt_in pool1 path1 deadline_block;
+  intermediate_amt_out = intermediate_amt_in;
+  GetAmountIn intermediate_amt_out pool1 path1 deadline_block;
   init_amt_in <- amt_in;
   VerifyValidAmountIn init_amt_in;
 
@@ -2287,17 +2161,15 @@ transition SwapZILForExactTokensTwice(
   wZil_address = get_from_address path1;
   MintZRC2 wZil_address init_amt_in;
 
+  (* transfers wZIL balance from this contract to user, that was obtained by using user's ZIL to mint wZIL *)
+  TransferZRC2 wZil_address _sender init_amt_in;  
+
   (* refund back remaining ZIL not used up in conversion to wZIL *)
   refund = builtin sub _amount init_amt_in;
   Send refund _sender;
 
-  (* pre-transfers wZIL balance from this contract straight to pool1 before swap *)
-  TransferZRC2ToPool pool1 path1 init_amt_in;
-
-  (* swap out ZRC2 tokens straight into pool2 *)
-  SwapZRC2Once pool1 path1 intermediate_amt_in pool2;
-  (* swap out ZRC2 tokens straight back to _sender *)
-  SwapZRC2Once pool2 path2 amount_out _sender;
+  SwapZRC2Once pool1 path1 init_amt_in intermediate_amt_out;
+  SwapZRC2Once pool2 path2 intermediate_amt_in amount_out;
 
   amt_in := zero_amount (* Reassign back to 0 *)
 end
@@ -2348,11 +2220,13 @@ transition SwapZILForExactTokensThrice(
   second_intermediate_amt_in <- amt_in;
   VerifyValidAmountIn second_intermediate_amt_in;
   
-  GetAmountIn second_intermediate_amt_in pool2 path2 deadline_block;
+  second_intermediate_amt_out = second_intermediate_amt_in;
+  GetAmountIn second_intermediate_amt_out pool2 path2 deadline_block;
   first_intermediate_amt_in <- amt_in;
   VerifyValidAmountIn first_intermediate_amt_in;
 
-  GetAmountIn first_intermediate_amt_in pool1 path1 deadline_block;
+  first_intermediate_amt_out = first_intermediate_amt_in;
+  GetAmountIn first_intermediate_amt_out pool1 path1 deadline_block;
   init_amt_in <- amt_in;
   VerifyValidAmountIn init_amt_in;
 
@@ -2370,19 +2244,16 @@ transition SwapZILForExactTokensThrice(
   wZil_address = get_from_address path1;
   MintZRC2 wZil_address init_amt_in;
 
+  (* transfers wZIL balance from this contract to user, that was obtained by using user's ZIL to mint wZIL *)
+  TransferZRC2 wZil_address _sender init_amt_in;  
+
   (* refund back remaining ZIL not used up in conversion to wZIL *)
   refund = builtin sub _amount init_amt_in;
   Send refund _sender;
 
-  (* pre-transfers wZIL balance from this contract straight to pool1 before swap *)
-  TransferZRC2ToPool pool1 path1 init_amt_in;
-
-  (* swap out ZRC2 tokens straight into pool2 *)
-  SwapZRC2Once pool1 path1 first_intermediate_amt_in pool2;
-  (* swap out ZRC2 tokens straight into pool3  *)
-  SwapZRC2Once pool2 path2 second_intermediate_amt_in pool3;
-  (* swap out ZRC2 tokens straight back to _sender *)
-  SwapZRC2Once pool3 path3 amount_out _sender;
+  SwapZRC2Once pool1 path1 init_amt_in first_intermediate_amt_out;
+  SwapZRC2Once pool2 path2 first_intermediate_amt_in second_intermediate_amt_out;
+  SwapZRC2Once pool3 path3 second_intermediate_amt_in amount_out;
 
   amt_in := zero_amount (* Reassign back to 0 *)
 end
@@ -2407,12 +2278,12 @@ transition RecipientAcceptTransfer(sender: ByStr20, recipient: ByStr20, amount: 
 end
 
 (* @dev: Handle callback when sending ZRC-2 tokens to the recipient using TransferFrom transition *)
-transition RecipientAcceptTransferFrom(initiator: ByStr20, sender: ByStr20, recipient: ByStr20, amount: Uint128)
+transition RecipientAcceptTransferFrom (initiator: ByStr20, sender: ByStr20, recipient: ByStr20, amount: Uint128)
 (* no-op *)
 end
 
 (* @dev: Handle callback when minting wZIL tokens to the contract *)
-transition RecipientAcceptMint(minter: ByStr20, recipient: ByStr20, amount: Uint128)
+transition RecipientAcceptMint (minter: ByStr20, recipient: ByStr20, amount: Uint128)
 (* no-op *)
 end
 

--- a/src/zilswap-v2/ZilSwapRouter.scilla
+++ b/src/zilswap-v2/ZilSwapRouter.scilla
@@ -931,12 +931,13 @@ transition AddLiquidityZIL(
     field reserve0 : Uint128,
     field reserve1 : Uint128,
     field v_reserve0 : Uint128,
-    field v_reserve1 : Uint128
+    field v_reserve1 : Uint128,
+    field amp_bps : Uint128
   end,
   amount_token_desired: Uint128,
   amount_token_min: Uint128,
   amount_wZIL_min: Uint128,
-  v_reserve_ratio_bounds: Pair Uint128 Uint128,
+  v_reserve_ratio_bounds: Pair Uint256 Uint256,
   to: ByStr20,
   deadline_block: BNum
 )
@@ -1024,18 +1025,30 @@ transition AddLiquidityZIL(
       (* Transfer pairing of wZIL and token to pool *)
       TransferZRC2ToPool pool token wZIL amount_token amount_wZIL
     end;
-    current_rate = frac v_r_b q112_u128 v_r_a;
-    match v_reserve_ratio_bounds with
-    | Pair l_bound u_bound =>
-      is_out_of_bound_vreserve = 
-        let l_b = uint128_ge current_rate l_bound in
-        let u_b = uint128_le current_rate u_bound in
-        andb l_b u_b;
-      match is_out_of_bound_vreserve with 
-      | True =>
-      | False =>
-        err = CodeOutOfBoundVReserve;
-        ThrowError err
+
+    amp <- & pool.amp_bps;
+    is_amp_pool = let is_eq = builtin eq amp bps in negb is_eq;
+    match is_amp_pool with 
+    | False => 
+    | True =>
+    (* only for amp pool *)
+      current_rate = 
+        let v_r_a_u256 = grow v_r_a in
+        let v_r_b_u256 = grow v_r_b in
+        let a = builtin mul v_r_b_u256 q112_u256 in
+        builtin div a v_r_a_u256;
+      match v_reserve_ratio_bounds with
+      | Pair l_bound u_bound =>
+        is_not_out_of_bound_vreserve = 
+          let l_b = uint256_ge current_rate l_bound in
+          let u_b = uint256_le current_rate u_bound in
+          andb l_b u_b;
+        match is_not_out_of_bound_vreserve with 
+        | True =>
+        | False =>
+          err = CodeOutOfBoundVReserve;
+          ThrowError err
+        end
       end
     end
   end;
@@ -1089,7 +1102,7 @@ transition RemoveLiquidity(
                 from: _sender; to: pool; amount: liquidity};
 
   (* Calls Burn transition on Pool, that transfers tokenA and tokenB back to _sender *)
-  msg_to_pool_2 = {_tag: "Burn"; _recipient: pool; _amount: zero_amount; to: _sender};
+  msg_to_pool_2 = {_tag: "Burn"; _recipient: pool; _amount: zero_amount};
   msgs = two_msgs msg_to_pool_1 msg_to_pool_2;
   send msgs
 end
@@ -1134,7 +1147,7 @@ transition RemoveLiquidityZIL(
                 from: _sender; to: pool; amount: liquidity};
 
   (* Calls Burn transition on Pool, that transfers token and wZIL back to _sender *)
-  msg_to_pool_2 = {_tag: "Burn"; _recipient: pool; _amount: zero_amount; to: _sender};
+  msg_to_pool_2 = {_tag: "Burn"; _recipient: pool; _amount: zero_amount};
 
   msgs = two_msgs msg_to_pool_1 msg_to_pool_2;
   send msgs;

--- a/src/zilswap-v2/ZilSwapRouter.scilla
+++ b/src/zilswap-v2/ZilSwapRouter.scilla
@@ -304,7 +304,7 @@ end
 
 (* @dev: Validate the pool contract with correct codehash *)
 procedure IsValidPoolContract(pool_address : ByStr20)
-  (* maybe_pool <- & pool_address as ByStr20 with _codehash end;
+  maybe_pool <- & pool_address as ByStr20 with _codehash end;
   match maybe_pool with
   | None =>
   | Some p =>
@@ -317,7 +317,7 @@ procedure IsValidPoolContract(pool_address : ByStr20)
       err = CodeInvalidPool;
       ThrowError err
     end
-  end *)
+  end
 end
 
 procedure AddOnceToPools(tokenA : ByStr20, tokenB : ByStr20, pool : ByStr20)
@@ -966,12 +966,9 @@ transition AddLiquidityZIL(
     accept;
     MintZRC2 wZIL amount_wZIL;
 
-    (* transfers wZIL balance from this contract to user, that was obtained by using user's ZIL to mint wZIL *)
-    TransferZRC2 wZIL _sender amount_wZIL;
-
     (* Transfer pairing of wZIL and token to pool *)
     TransferFromZRC2 token _sender pool amount_token;
-    TransferFromZRC2 wZIL _sender pool amount_wZIL
+    TransferZRC2 wZIL pool amount_wZIL
   | False =>
     (* pool with existing liquidity *)
     (* check how much wZIL is required to fulfil amount_token_desired pairing *)
@@ -994,16 +991,13 @@ transition AddLiquidityZIL(
       accept;
       MintZRC2 wZIL amount_wZIL;
 
-      (* transfers wZIL balance from this contract to user, that was obtained by using user's ZIL to mint wZIL *)
-      TransferZRC2 wZIL _sender amount_wZIL;
-
       (* refund back remaining ZIL not used up in conversion to wZIL *)
       refund = builtin sub _amount amount_wZIL;
       Send refund _sender;
 
       (* Transfer pairing of wZIL and token to pool *)
       TransferFromZRC2 token _sender pool amount_token;
-      TransferFromZRC2 wZIL _sender pool amount_wZIL
+      TransferZRC2 wZIL pool amount_wZIL
     | False =>
       (* insufficient wZIL provided *)
       (* check how many tokens are required to fulfil wZIL pairing, based on insufficient wZIL provided *)
@@ -1021,13 +1015,10 @@ transition AddLiquidityZIL(
       (* Send ZIL to wZIL contract and mint wZIL *)
       accept;
       MintZRC2 wZIL amount_wZIL;
-    
-      (* transfers wZIL balance from this contract to user, that was obtained by using user's ZIL to mint wZIL *)
-      TransferZRC2 wZIL _sender amount_wZIL;
       
       (* Transfer pairing of wZIL and token to pool *)
       TransferFromZRC2 token _sender pool amount_token;
-      TransferFromZRC2 wZIL _sender pool amount_wZIL
+      TransferZRC2 wZIL pool amount_wZIL
     end;
 
     amp <- & pool.amp_bps;

--- a/tests/zilswap-v2/doubleSwapZil.test.js
+++ b/tests/zilswap-v2/doubleSwapZil.test.js
@@ -1184,11 +1184,64 @@ setup = async (isAmpPool) => {
       },
       {
         vname: 'v_reserve_ratio_bounds',
-        type: 'Pair (Uint128) (Uint128)',
+        type: 'Pair (Uint256) (Uint256)',
         value: {
           "constructor": "Pair",
-          "argtypes": ["Uint128", "Uint128"],
-          "arguments": ["0", "1000000000000"]
+          "argtypes": ["Uint256", "Uint256"],
+          "arguments": ["0", "100000000000000000000000000000000000"]
+        }
+      },
+      {
+        vname: 'to',
+        type: 'ByStr20',
+        value: `${owner.address.toLowerCase()}`,
+      }
+    ],
+    init_liquidity, false, true
+  )
+  expect(tx.status).toEqual(2)
+
+  tx = await callContract(
+    owner.key, router,
+    'AddLiquidityZIL',
+    [
+      {
+        vname: 'token',
+        type: 'ByStr20',
+        value: bridgeTokenAddress,
+      },
+      {
+        vname: 'wZIL',
+        type: 'ByStr20',
+        value: wZil,
+      },
+      {
+        vname: 'pool',
+        type: 'ByStr20',
+        value: `${pool2.address.toLowerCase()}`,
+      },
+      {
+        vname: 'amount_token_desired',
+        type: 'Uint128',
+        value: `${(new BigNumber(init_liquidity)).shiftedBy(12).toString()}`,
+      },
+      {
+        vname: 'amount_token_min',
+        type: 'Uint128',
+        value: '0',
+      },
+      {
+        vname: 'amount_wZIL_min',
+        type: 'Uint128',
+        value: '0',
+      },
+      {
+        vname: 'v_reserve_ratio_bounds',
+        type: 'Pair (Uint256) (Uint256)',
+        value: {
+          "constructor": "Pair",
+          "argtypes": ["Uint256", "Uint256"],
+          "arguments": ["0", "100000000000000000000000000000000000"]
         }
       },
       {

--- a/tests/zilswap-v2/quadSwapZil.test.js
+++ b/tests/zilswap-v2/quadSwapZil.test.js
@@ -1,0 +1,670 @@
+const { getDefaultAccount, createRandomAccount } = require('../../scripts/account.js');
+const { deployZilswapV2Router, deployZilswapV2Pool, useFungibleToken, useWrappedZIL } = require('../../scripts/deploy.js');
+const { callContract, getBalance, getContract } = require('../../scripts/call.js')
+const { getContractCodeHash } = require('./helper.js');
+const { default: BigNumber } = require('bignumber.js');
+
+let token0, token1, token2, token3, token4, owner, feeAccount, pool1, pool2, pool3, pool4, router
+const init_liquidity = 10000
+let amountIn = 1000;
+let amountOutMin = 10;
+const codehash = getContractCodeHash("./src/zilswap-v2/ZilSwapPool.scilla");
+
+describe('Zilswap swap exact zrc2/zil for zil/zrc2 (Non-amp pool)', () => {
+
+  beforeAll(async () => {
+    await setup(false)
+  })
+
+  afterAll(async () => {
+    // Increase Allowance for LP Token (to transfer LP token to Pool) for non ZIL pool
+    const txIncreaseAllowancePool1 = await callContract(
+      owner.key, pool1,
+      'IncreaseAllowance',
+      [
+        {
+          vname: 'spender',
+          type: 'ByStr20',
+          value: router.address.toLowerCase(),
+        },
+        {
+          vname: 'amount',
+          type: 'Uint128',
+          value: `${newPool1State.balances[owner.address.toLowerCase()]}`,
+        },
+      ],
+      0, false, false
+    )
+    expect(txIncreaseAllowancePool1.status).toEqual(2)
+
+    // RemoveLiquidity
+    const txRemoveLiquidityPool1 = await callContract(
+      owner.key, router,
+      'RemoveLiquidity',
+      [
+        {
+          vname: 'tokenA',
+          type: 'ByStr20',
+          value: token0.address,
+        },
+        {
+          vname: 'tokenB',
+          type: 'ByStr20',
+          value: token1.address,
+        },
+        {
+          vname: 'pool',
+          type: 'ByStr20',
+          value: `${pool1.address.toLowerCase()}`,
+        },
+        {
+          vname: 'liquidity',
+          type: 'Uint128',
+          value: `${newPool1State.balances[owner.address.toLowerCase()]}`,
+        },
+        {
+          vname: 'amountA_min',
+          type: 'Uint128',
+          value: '0',
+        },
+        {
+          vname: 'amountB_min',
+          type: 'Uint128',
+          value: '0',
+        }
+      ],
+      0, false, true
+    )
+    expect(txRemoveLiquidityPool1.status).toEqual(2)
+
+    // Increase Allowance for LP Token (to transfer LP token to Pool) for non ZIL pool
+    const txIncreaseAllowancePool2 = await callContract(
+      owner.key, pool2,
+      'IncreaseAllowance',
+      [
+        {
+          vname: 'spender',
+          type: 'ByStr20',
+          value: router.address.toLowerCase(),
+        },
+        {
+          vname: 'amount',
+          type: 'Uint128',
+          value: `${newPool2State.balances[owner.address.toLowerCase()]}`,
+        },
+      ],
+      0, false, false
+    )
+    expect(txIncreaseAllowancePool2.status).toEqual(2)
+
+    // RemoveLiquidity
+    const txRemoveLiquidityPool2 = await callContract(
+      owner.key, router,
+      'RemoveLiquidity',
+      [
+        {
+          vname: 'tokenA',
+          type: 'ByStr20',
+          value: token1.address,
+        },
+        {
+          vname: 'tokenB',
+          type: 'ByStr20',
+          value: token2.address,
+        },
+        {
+          vname: 'pool',
+          type: 'ByStr20',
+          value: `${pool2.address.toLowerCase()}`,
+        },
+        {
+          vname: 'liquidity',
+          type: 'Uint128',
+          value: `${newPool2State.balances[owner.address.toLowerCase()]}`,
+        },
+        {
+          vname: 'amountA_min',
+          type: 'Uint128',
+          value: '0',
+        },
+        {
+          vname: 'amountB_min',
+          type: 'Uint128',
+          value: '0',
+        }
+      ],
+      0, false, true
+    )
+    expect(txRemoveLiquidityPool2.status).toEqual(2)
+
+    // Increase Allowance for LP Token (to transfer LP token to Pool) for non ZIL pool
+    const txIncreaseAllowancePool3 = await callContract(
+      owner.key, pool3,
+      'IncreaseAllowance',
+      [
+        {
+          vname: 'spender',
+          type: 'ByStr20',
+          value: router.address.toLowerCase(),
+        },
+        {
+          vname: 'amount',
+          type: 'Uint128',
+          value: `${newPool3State.balances[owner.address.toLowerCase()]}`,
+        },
+      ],
+      0, false, false
+    )
+    expect(txIncreaseAllowancePool3.status).toEqual(2)
+
+    // RemoveLiquidity
+    const txRemoveLiquidityPool3 = await callContract(
+      owner.key, router,
+      'RemoveLiquidity',
+      [
+        {
+          vname: 'tokenA',
+          type: 'ByStr20',
+          value: token2.address,
+        },
+        {
+          vname: 'tokenB',
+          type: 'ByStr20',
+          value: token3.address,
+        },
+        {
+          vname: 'pool',
+          type: 'ByStr20',
+          value: `${pool3.address.toLowerCase()}`,
+        },
+        {
+          vname: 'liquidity',
+          type: 'Uint128',
+          value: `${newPool3State.balances[owner.address.toLowerCase()]}`,
+        },
+        {
+          vname: 'amountA_min',
+          type: 'Uint128',
+          value: '0',
+        },
+        {
+          vname: 'amountB_min',
+          type: 'Uint128',
+          value: '0',
+        }
+      ],
+      0, false, true
+    )
+    expect(txRemoveLiquidityPool3.status).toEqual(2)
+
+    // Increase Allowance for LP Token (to transfer LP token to Pool) for ZIL pool
+    const txIncreaseAllowancePool4 = await callContract(
+      owner.key, pool4,
+      'IncreaseAllowance',
+      [
+        {
+          vname: 'spender',
+          type: 'ByStr20',
+          value: router.address.toLowerCase(),
+        },
+        {
+          vname: 'amount',
+          type: 'Uint128',
+          value: `${newPool4State.balances[owner.address.toLowerCase()]}`,
+        },
+      ],
+      0, false, false
+    )
+    expect(txIncreaseAllowancePool4.status).toEqual(2)
+
+    // RemoveLiquidityZIL
+    const txRemoveLiquidityPool4 = await callContract(
+      owner.key, router,
+      'RemoveLiquidityZIL',
+      [
+        {
+          vname: 'token',
+          type: 'ByStr20',
+          value: token3.address,
+        },
+        {
+          vname: 'wZIL',
+          type: 'ByStr20',
+          value: token4.address,
+        },
+        {
+          vname: 'pool',
+          type: 'ByStr20',
+          value: `${pool4.address.toLowerCase()}`,
+        },
+        {
+          vname: 'liquidity',
+          type: 'Uint128',
+          value: `${newPool4State.balances[owner.address.toLowerCase()]}`,
+        },
+        {
+          vname: 'amount_token_min',
+          type: 'Uint128',
+          value: '0',
+        },
+        {
+          vname: 'amount_wZIL_min',
+          type: 'Uint128',
+          value: '0',
+        }
+      ],
+      0, false, true
+    )
+    expect(txRemoveLiquidityPool4.status).toEqual(2)
+  })
+
+  test('swap exact ZIL for token (Non-amp pool)', async () => {
+    const txSwapExactZilForTokensQuad = await callContract(
+      owner.key, router,
+      'SwapExactZILForTokensQuad',
+      [
+        {
+          vname: 'amount_out_min',
+          type: 'Uint128',
+          value: `${(new BigNumber(amountOutMin)).shiftedBy(12).toString()}`,
+        },
+        {
+          vname: 'pool1',
+          type: 'ByStr20',
+          value: pool4.address.toLowerCase(),
+        },
+        {
+          vname: 'pool2',
+          type: 'ByStr20',
+          value: pool3.address.toLowerCase(),
+        },
+        {
+          vname: 'pool3',
+          type: 'ByStr20',
+          value: pool2.address.toLowerCase(),
+        },
+        {
+          vname: 'pool4',
+          type: 'ByStr20',
+          value: pool1.address.toLowerCase(),
+        },
+        {
+          vname: 'path1',
+          type: 'Pair (ByStr20) (ByStr20)',
+          value: {
+            "constructor": "Pair",
+            "argtypes": ["ByStr20", "ByStr20"],
+            "arguments": [token4.address.toLowerCase(), token3.address.toLowerCase()]
+          }
+        },
+        {
+          vname: 'path2',
+          type: 'Pair (ByStr20) (ByStr20)',
+          value: {
+            "constructor": "Pair",
+            "argtypes": ["ByStr20", "ByStr20"],
+            "arguments": [token3.address.toLowerCase(), token2.address.toLowerCase()]
+          }
+        },
+        {
+          vname: 'path3',
+          type: 'Pair (ByStr20) (ByStr20)',
+          value: {
+            "constructor": "Pair",
+            "argtypes": ["ByStr20", "ByStr20"],
+            "arguments": [token2.address.toLowerCase(), token1.address.toLowerCase()]
+          }
+        },
+        {
+          vname: 'path4',
+          type: 'Pair (ByStr20) (ByStr20)',
+          value: {
+            "constructor": "Pair",
+            "argtypes": ["ByStr20", "ByStr20"],
+            "arguments": [token1.address.toLowerCase(), token0.address.toLowerCase()]
+          }
+        },
+      ],
+      amountIn, false, true
+    )
+    expect(txSwapExactZilForTokensQuad.status).toEqual(2)
+  })
+ })
+
+// Helper functions
+getAmpBps = (isAmpPool) => {
+  ampBps = isAmpPool ? "15000" : "10000";
+  return ampBps;
+}
+
+setup = async (isAmpPool) => {
+  owner = getDefaultAccount()
+  feeAccount = await createRandomAccount(owner.key)
+  router = (await deployZilswapV2Router(owner.key, { governor: null, codehash }))[0]
+  token0 = (await useFungibleToken(owner.key, { symbol: 'TKN0', decimals: 12, supply: '100000000000000000000000000000000000000' }, router.address.toLowerCase(), null))[0]
+  token1 = (await useFungibleToken(owner.key, { symbol: 'TKN1', decimals: 12, supply: '100000000000000000000000000000000000000' }, router.address.toLowerCase(), null))[0]
+  token2 = (await useFungibleToken(owner.key, { symbol: 'TKN2', decimals: 12, supply: '100000000000000000000000000000000000000' }, router.address.toLowerCase(), null))[0]
+  token3 = (await useFungibleToken(owner.key, { symbol: 'TKN2', decimals: 12, supply: '100000000000000000000000000000000000000' }, router.address.toLowerCase(), null))[0]
+  token4 = (await useWrappedZIL(owner.key, { name: 'WrappedZIL', symbol: 'WZIL', decimals: 12, initSupply: '100000000000000000000000000000000000000' }, router.address.toLowerCase(), null))[0]
+
+  const txSetFeeConfig = await callContract(
+    owner.key, router,
+    'SetFeeConfiguration',
+    [
+      {
+        vname: 'config',
+        type: 'Pair ByStr20 Uint128',
+        value: {
+          "constructor": "Pair",
+          "argtypes": ["ByStr20", "Uint128"],
+          "arguments": [`${feeAccount.address}`, "1000"] // 10%
+        }
+      },
+    ],
+    0, false, false
+  )
+  expect(txSetFeeConfig.status).toEqual(2)
+
+  if (parseInt(token0.address, 16) < parseInt(token1.address, 16))
+    pool1 = (await deployZilswapV2Pool(owner.key, { factory: router, token0, token1, init_amp_bps: getAmpBps(isAmpPool) }))[0]
+  else
+    pool1 = (await deployZilswapV2Pool(owner.key, { factory: router, token0: token1, token1: token0, init_amp_bps: getAmpBps(isAmpPool) }))[0]
+
+  if (parseInt(token1.address, 16) < parseInt(token2.address, 16))
+    pool2 = (await deployZilswapV2Pool(owner.key, { factory: router, token0: token1, token1: token2, init_amp_bps: getAmpBps(isAmpPool) }))[0]
+  else
+    pool2 = (await deployZilswapV2Pool(owner.key, { factory: router, token0: token2, token1: token1, init_amp_bps: getAmpBps(isAmpPool) }))[0]
+
+  if (parseInt(token2.address, 16) < parseInt(token3.address, 16))
+    pool3 = (await deployZilswapV2Pool(owner.key, { factory: router, token0: token2, token1: token3, init_amp_bps: getAmpBps(isAmpPool) }))[0]
+  else
+    pool3 = (await deployZilswapV2Pool(owner.key, { factory: router, token0: token3, token1: token2, init_amp_bps: getAmpBps(isAmpPool) }))[0]
+
+  if (parseInt(token3.address, 16) < parseInt(token4.address, 16))
+    pool4 = (await deployZilswapV2Pool(owner.key, { factory: router, token0: token3, token1: token4, init_amp_bps: getAmpBps(isAmpPool) }))[0]
+  else
+    pool4 = (await deployZilswapV2Pool(owner.key, { factory: router, token0: token4, token1: token3, init_amp_bps: getAmpBps(isAmpPool) }))[0]
+
+  const txAddPool1 = await callContract(
+    owner.key, router,
+    'AddPool',
+    [
+      {
+        vname: 'pool',
+        type: 'ByStr20',
+        value: pool1.address.toLowerCase(),
+      },
+    ],
+    0, false, false
+  )
+  expect(txAddPool1.status).toEqual(2)
+
+  const txAddPool2 = await callContract(
+    owner.key, router,
+    'AddPool',
+    [
+      {
+        vname: 'pool',
+        type: 'ByStr20',
+        value: pool2.address.toLowerCase(),
+      },
+    ],
+    0, false, false
+  )
+  expect(txAddPool2.status).toEqual(2)
+
+  const txAddPool3 = await callContract(
+    owner.key, router,
+    'AddPool',
+    [
+      {
+        vname: 'pool',
+        type: 'ByStr20',
+        value: pool3.address.toLowerCase(),
+      },
+    ],
+    0, false, false
+  )
+  expect(txAddPool3.status).toEqual(2)
+
+  const txAddPool4 = await callContract(
+    owner.key, router,
+    'AddPool',
+    [
+      {
+        vname: 'pool',
+        type: 'ByStr20',
+        value: pool4.address.toLowerCase(),
+      },
+    ],
+    0, false, false
+  )
+  expect(txAddPool4.status).toEqual(2)
+
+  const txAddLiquidity1 = await callContract(
+    owner.key, router,
+    'AddLiquidity',
+    [
+      {
+        vname: 'tokenA',
+        type: 'ByStr20',
+        value: token0.address,
+      },
+      {
+        vname: 'tokenB',
+        type: 'ByStr20',
+        value: token1.address,
+      },
+      {
+        vname: 'pool',
+        type: 'ByStr20',
+        value: `${pool1.address.toLowerCase()}`,
+      },
+      {
+        vname: 'amountA_desired',
+        type: 'Uint128',
+        value: `${(new BigNumber(init_liquidity)).shiftedBy(12).toString()}`,
+      },
+      {
+        vname: 'amountB_desired',
+        type: 'Uint128',
+        value: `${(new BigNumber(init_liquidity)).shiftedBy(12).toString()}`,
+      },
+      {
+        vname: 'amountA_min',
+        type: 'Uint128',
+        value: '0',
+      },
+      {
+        vname: 'amountB_min',
+        type: 'Uint128',
+        value: '0',
+      },
+      {
+        vname: 'v_reserve_ratio_bounds',
+        type: 'Pair (Uint256) (Uint256)',
+        value: {
+          "constructor": "Pair",
+          "argtypes": ["Uint256", "Uint256"],
+          "arguments": ["0", "1000000000000"]
+        }
+      },
+      {
+        vname: 'to',
+        type: 'ByStr20',
+        value: `${owner.address.toLowerCase()}`,
+      },
+    ],
+    0, false, true
+  )
+  expect(txAddLiquidity1.status).toEqual(2)
+
+  const txAddLiquidity2 = await callContract(
+    owner.key, router,
+    'AddLiquidity',
+    [
+      {
+        vname: 'tokenA',
+        type: 'ByStr20',
+        value: token1.address,
+      },
+      {
+        vname: 'tokenB',
+        type: 'ByStr20',
+        value: token2.address,
+      },
+      {
+        vname: 'pool',
+        type: 'ByStr20',
+        value: `${pool2.address.toLowerCase()}`,
+      },
+      {
+        vname: 'amountA_desired',
+        type: 'Uint128',
+        value: `${(new BigNumber(init_liquidity)).shiftedBy(12).toString()}`,
+      },
+      {
+        vname: 'amountB_desired',
+        type: 'Uint128',
+        value: `${(new BigNumber(init_liquidity)).shiftedBy(12).toString()}`,
+      },
+      {
+        vname: 'amountA_min',
+        type: 'Uint128',
+        value: '0',
+      },
+      {
+        vname: 'amountB_min',
+        type: 'Uint128',
+        value: '0',
+      },
+      {
+        vname: 'v_reserve_ratio_bounds',
+        type: 'Pair (Uint256) (Uint256)',
+        value: {
+          "constructor": "Pair",
+          "argtypes": ["Uint256", "Uint256"],
+          "arguments": ["0", "1000000000000"]
+        }
+      },
+      {
+        vname: 'to',
+        type: 'ByStr20',
+        value: `${owner.address.toLowerCase()}`,
+      },
+    ],
+    0, false, true
+  )
+  expect(txAddLiquidity2.status).toEqual(2)
+
+  const txAddLiquidity3 = await callContract(
+    owner.key, router,
+    'AddLiquidity',
+    [
+      {
+        vname: 'tokenA',
+        type: 'ByStr20',
+        value: token2.address,
+      },
+      {
+        vname: 'tokenB',
+        type: 'ByStr20',
+        value: token3.address,
+      },
+      {
+        vname: 'pool',
+        type: 'ByStr20',
+        value: `${pool3.address.toLowerCase()}`,
+      },
+      {
+        vname: 'amountA_desired',
+        type: 'Uint128',
+        value: `${(new BigNumber(init_liquidity)).shiftedBy(12).toString()}`,
+      },
+      {
+        vname: 'amountB_desired',
+        type: 'Uint128',
+        value: `${(new BigNumber(init_liquidity)).shiftedBy(12).toString()}`,
+      },
+      {
+        vname: 'amountA_min',
+        type: 'Uint128',
+        value: '0',
+      },
+      {
+        vname: 'amountB_min',
+        type: 'Uint128',
+        value: '0',
+      },
+      {
+        vname: 'v_reserve_ratio_bounds',
+        type: 'Pair (Uint256) (Uint256)',
+        value: {
+          "constructor": "Pair",
+          "argtypes": ["Uint256", "Uint256"],
+          "arguments": ["0", "1000000000000"]
+        }
+      },
+      {
+        vname: 'to',
+        type: 'ByStr20',
+        value: `${owner.address.toLowerCase()}`,
+      },
+    ],
+    0, false, true
+  )
+  expect(txAddLiquidity3.status).toEqual(2)
+
+  const txAddLiquidity4 = await callContract(
+    owner.key, router,
+    'AddLiquidityZIL',
+    [
+      {
+        vname: 'token',
+        type: 'ByStr20',
+        value: token3.address,
+      },
+      {
+        vname: 'wZIL',
+        type: 'ByStr20',
+        value: token4.address,
+      },
+      {
+        vname: 'pool',
+        type: 'ByStr20',
+        value: `${pool4.address.toLowerCase()}`,
+      },
+      {
+        vname: 'amount_token_desired',
+        type: 'Uint128',
+        value: `${(new BigNumber(init_liquidity)).shiftedBy(12).toString()}`,
+      },
+      {
+        vname: 'amount_token_min',
+        type: 'Uint128',
+        value: '0',
+      },
+      {
+        vname: 'amount_wZIL_min',
+        type: 'Uint128',
+        value: '0',
+      },
+      {
+        vname: 'v_reserve_ratio_bounds',
+        type: 'Pair (Uint256) (Uint256)',
+        value: {
+          "constructor": "Pair",
+          "argtypes": ["Uint256", "Uint256"],
+          "arguments": ["0", "1000000000000"]
+        }
+      },
+      {
+        vname: 'to',
+        type: 'ByStr20',
+        value: `${owner.address.toLowerCase()}`,
+      }
+    ],
+    init_liquidity, false, true
+  )
+  expect(txAddLiquidity4.status).toEqual(2)
+}

--- a/tests/zilswap-v2/singleSwapZil.test.js
+++ b/tests/zilswap-v2/singleSwapZil.test.js
@@ -704,7 +704,6 @@ setup = async (isAmpPool) => {
     init_liquidity, false, true
   )
   expect(tx.status).toEqual(2)
-  console.log(tx.receipt.event_logs)
 
   tx = await callContract(
     owner.key, router,
@@ -758,7 +757,6 @@ setup = async (isAmpPool) => {
     init_liquidity, false, true
   )
   expect(tx.status).toEqual(2)
-  console.log(tx.receipt.event_logs[7])
 }
 
 // validate pool reserves (both amp and non-amp pools)

--- a/tests/zilswap-v2/singleSwapZil.test.js
+++ b/tests/zilswap-v2/singleSwapZil.test.js
@@ -704,6 +704,7 @@ setup = async (isAmpPool) => {
     init_liquidity, false, true
   )
   expect(tx.status).toEqual(2)
+  console.log(tx.receipt.event_logs)
 
   tx = await callContract(
     owner.key, router,
@@ -757,6 +758,7 @@ setup = async (isAmpPool) => {
     init_liquidity, false, true
   )
   expect(tx.status).toEqual(2)
+  console.log(tx.receipt.event_logs[7])
 }
 
 // validate pool reserves (both amp and non-amp pools)

--- a/tests/zilswap-v2/singleSwapZil.test.js
+++ b/tests/zilswap-v2/singleSwapZil.test.js
@@ -5,7 +5,10 @@ const { getContractCodeHash } = require('./helper.js');
 const { default: BigNumber } = require('bignumber.js');
 
 let token0, token1, token, wZil, owner, feeAccount, tx, pool, router, prevPoolState, newPoolState, prevToken0State, prevToken1State, newToken0State, newToken1State, prevOwnerZilBalance, newOwnerZilBalance
+const ONE_MILLION = 1_000_000
 const init_liquidity = 10000
+const ONE_THOUSAND = 1000
+const ONE_HUNDRED = 100
 let amountIn = 100;
 let amountInMax = 1000;
 let amountOut = 100;
@@ -685,11 +688,11 @@ setup = async (isAmpPool) => {
       },
       {
         vname: 'v_reserve_ratio_bounds',
-        type: 'Pair (Uint128) (Uint128)',
+        type: 'Pair (Uint256) (Uint256)',
         value: {
           "constructor": "Pair",
-          "argtypes": ["Uint128", "Uint128"],
-          "arguments": ["0", "1000000000000"]
+          "argtypes": ["Uint256", "Uint256"],
+          "arguments": ["0", "100000000000000000000000000000000000"]
         }
       },
       {
@@ -701,6 +704,61 @@ setup = async (isAmpPool) => {
     init_liquidity, false, true
   )
   expect(tx.status).toEqual(2)
+  console.log(tx.receipt.event_logs)
+
+  tx = await callContract(
+    owner.key, router,
+    'AddLiquidityZIL',
+    [
+      {
+        vname: 'token',
+        type: 'ByStr20',
+        value: token,
+      },
+      {
+        vname: 'wZIL',
+        type: 'ByStr20',
+        value: wZil,
+      },
+      {
+        vname: 'pool',
+        type: 'ByStr20',
+        value: `${pool.address.toLowerCase()}`,
+      },
+      {
+        vname: 'amount_token_desired',
+        type: 'Uint128',
+        value: `${(new BigNumber(init_liquidity)).shiftedBy(12).toString()}`,
+      },
+      {
+        vname: 'amount_token_min',
+        type: 'Uint128',
+        value: '0',
+      },
+      {
+        vname: 'amount_wZIL_min',
+        type: 'Uint128',
+        value: '0',
+      },
+      {
+        vname: 'v_reserve_ratio_bounds',
+        type: 'Pair (Uint256) (Uint256)',
+        value: {
+          "constructor": "Pair",
+          "argtypes": ["Uint256", "Uint256"],
+          "arguments": ["0", "100000000000000000000000000000000000"]
+        }
+      },
+      {
+        vname: 'to',
+        type: 'ByStr20',
+        value: `${owner.address.toLowerCase()}`,
+      }
+    ],
+    init_liquidity, false, true
+  )
+  expect(tx.status).toEqual(2)
+  console.log(tx.receipt.event_logs[7])
 }
 
 // validate pool reserves (both amp and non-amp pools)

--- a/tests/zilswap-v2/tripleSwapZil.test.js
+++ b/tests/zilswap-v2/tripleSwapZil.test.js
@@ -1030,7 +1030,7 @@ describe('Zilswap swap exact zrc2/zil for zil/zrc2 (Amp pool)', () => {
   })
 })
 
-describe('Zilswap swap zrc2 for exact zrc2 (Amp pool)', () => {
+describe('Zilswap swap zrc2/zil for exact zil/zrc2 (Amp pool)', () => {
 
   beforeAll(async () => {
     await setup(true)
@@ -1613,10 +1613,10 @@ setup = async (isAmpPool) => {
       },
       {
         vname: 'v_reserve_ratio_bounds',
-        type: 'Pair (Uint128) (Uint128)',
+        type: 'Pair (Uint256) (Uint256)',
         value: {
           "constructor": "Pair",
-          "argtypes": ["Uint128", "Uint128"],
+          "argtypes": ["Uint256", "Uint256"],
           "arguments": ["0", "1000000000000"]
         }
       },

--- a/tests/zilswap-v2/tripleSwapZil.test.js
+++ b/tests/zilswap-v2/tripleSwapZil.test.js
@@ -1030,7 +1030,7 @@ describe('Zilswap swap exact zrc2/zil for zil/zrc2 (Amp pool)', () => {
   })
 })
 
-describe('Zilswap swap zrc2/zil for exact zil/zrc2 (Amp pool)', () => {
+describe('Zilswap swap zrc2 for exact zrc2 (Amp pool)', () => {
 
   beforeAll(async () => {
     await setup(true)
@@ -1613,10 +1613,10 @@ setup = async (isAmpPool) => {
       },
       {
         vname: 'v_reserve_ratio_bounds',
-        type: 'Pair (Uint256) (Uint256)',
+        type: 'Pair (Uint128) (Uint128)',
         value: {
           "constructor": "Pair",
-          "argtypes": ["Uint256", "Uint256"],
+          "argtypes": ["Uint128", "Uint128"],
           "arguments": ["0", "1000000000000"]
         }
       },


### PR DESCRIPTION
- optimise swap by abstracting out transfer msgs, and only performing transfer fxns for the initial transfer into the first pool
- current limit is triple swaps (quad swaps max depth)